### PR TITLE
Chore/improve gh actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,65 +1,83 @@
 name: Run test and lint
 
 on:
-  pull_request:
-    branches: [master]
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
 
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
-          cache: "gradle"
+    lint:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v4
 
-      - name: Grant execute permissions for gradlew
-        run: chmod +x gradlew
+            -   name: Setup JDK 17
+                uses: actions/setup-java@v4
+                with:
+                    distribution: "temurin"
+                    java-version: "17"
+                    cache: "gradle"
 
-      - name: Run Android Lint
-        run: ./gradlew lint
+            -   name: Setup Android
+                if: ${{ env.ACT }} # Only run on local act setups
+                uses: android-actions/setup-android@v2
 
-      - name: Upload Lint Reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: lint-reports
-          path: |
-            **/build/reports/lint-results.html
-            **/build/reports/lint-results.xml
+            -   name: Setup Gradle
+                uses: gradle/actions/setup-gradle@v4
 
-  test:
-    needs: [lint]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+            -   name: Grant execute permissions for gradlew
+                run: chmod +x gradlew
 
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
-          cache: "gradle"
+            -   name: Run Android Lint
+                run: ./gradlew ktlintFormat --no-configuration-cache
 
-      - name: Grant execute permissions for gradlew
-        run: chmod +x gradlew
+            -   name: Upload Lint Reports
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: lint-reports
+                    path: |
+                        **/build/reports/ktlint/**/lint-results.html
+                        **/build/reports/ktlint/**/lint-results.txt
 
-      - name: Run Unit Tests
-        run: ./gradlew test --continue
+    test:
+        runs-on: ubuntu-latest
+        permissions:
+            checks: write
+        steps:
+            -   uses: actions/checkout@v4
 
-      - name: Upload Test Reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-reports
-          path: '**/build/reports/tests/'
+            -   name: Setup JDK 17
+                uses: actions/setup-java@v4
+                with:
+                    distribution: "temurin"
+                    java-version: "17"
+                    cache: "gradle"
 
-      - name: Publish Test Results
-        uses: mikepenz/action-junit-report@v4
-        if: success() || failure()
-        with:
-          report_paths: '**/build/test-results/**/TEST-*.xml'
+            -   name: Setup Android
+                if: ${{ env.ACT }} # Only run on local act setups
+                uses: android-actions/setup-android@v2
+
+            -   name: Setup Gradle
+                uses: gradle/actions/setup-gradle@v4
+
+            -   name: Grant execute permissions for gradlew
+                run: chmod +x gradlew
+
+            -   name: Run Unit Tests
+                run: ./gradlew test --continue
+
+            -   name: Upload Test Reports
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: test-reports
+                    path: '**/build/reports/tests/'
+
+            -   name: Publish Test Results
+                uses: mikepenz/action-junit-report@v4
+                if: success() || failure()
+                with:
+                    report_paths: '**/build/test-results/**/TEST-*.xml'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,6 @@ jobs:
                 with:
                     distribution: "temurin"
                     java-version: "17"
-                    cache: "gradle"
 
             -   name: Setup Android
                 if: ${{ env.ACT }} # Only run on local act setups
@@ -44,6 +43,8 @@ jobs:
     test:
         runs-on: ubuntu-latest
         permissions:
+            contents: read
+            packages: write
             checks: write
         steps:
             -   uses: actions/checkout@v4
@@ -53,7 +54,6 @@ jobs:
                 with:
                     distribution: "temurin"
                     java-version: "17"
-                    cache: "gradle"
 
             -   name: Setup Android
                 if: ${{ env.ACT }} # Only run on local act setups

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Run test and lint
+name: Run unit tests and lint
 
 on:
     push:
@@ -7,7 +7,6 @@ on:
         branches: [ master ]
 
 jobs:
-
     lint:
         runs-on: ubuntu-latest
         steps:
@@ -34,7 +33,7 @@ jobs:
                 run: ./gradlew ktlintFormat --no-configuration-cache
 
             -   name: Upload Lint Reports
-                if: always()
+                if: ${{ !env.ACT }}
                 uses: actions/upload-artifact@v4
                 with:
                     name: lint-reports
@@ -70,7 +69,7 @@ jobs:
                 run: ./gradlew test --continue
 
             -   name: Upload Test Reports
-                if: always()
+                if: ${{ !env.ACT }}
                 uses: actions/upload-artifact@v4
                 with:
                     name: test-reports
@@ -78,6 +77,6 @@ jobs:
 
             -   name: Publish Test Results
                 uses: mikepenz/action-junit-report@v4
-                if: success() || failure()
+                if: (success() || failure()) && ${{ !env.ACT }}
                 with:
                     report_paths: '**/build/test-results/**/TEST-*.xml'

--- a/build-logic/.gitignore
+++ b/build-logic/.gitignore
@@ -1,2 +1,3 @@
 /conventions/build/
 /.gradle/
+/.kotlin/

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
 # org.gradle.parallel=true
+
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
@@ -24,3 +25,4 @@ android.nonTransitiveRClass=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
+org.gradle.configuration-cache.problems=warn


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflow configuration for running tests and linting, as well as minor changes to the `.gitignore` and `gradle.properties` files. The most important changes are listed below:

### Workflow Configuration Updates:

* Renamed the job from "Run test and lint" to "Run unit tests and lint" and added a trigger for pushes to the `master` branch. (`.github/workflows/pull_request.yml`)
* Added steps to set up Android and Gradle environments, and updated the lint command to use `ktlintFormat` instead of `lint`. (`.github/workflows/pull_request.yml`)
* Updated the paths for uploading lint reports to match the new `ktlint` structure. (`.github/workflows/pull_request.yml`)
* Added permissions for the `test` job and updated conditions for uploading test reports and publishing test results to exclude local `act` setups. (`.github/workflows/pull_request.yml`)

### Minor Configuration Updates:

* Added `/.kotlin/` to the `.gitignore` file to ignore Kotlin-specific build directories. (`build-logic/.gitignore`)
* Added a new property `org.gradle.configuration-cache.problems=warn` to the `gradle.properties` file to handle configuration cache problems with a warning. (`gradle.properties`)