### PR TITLE
Fix/clear operations on new game

### DIFF
--- a/data/game/src/main/java/com/example/data/game/AndroidProtoOperationRepository.kt
+++ b/data/game/src/main/java/com/example/data/game/AndroidProtoOperationRepository.kt
@@ -3,8 +3,8 @@ package com.example.data.game
 import com.example.data.core.proto.ProtoStorageFactory
 import com.example.data.game.mappers.toOperation
 import com.example.data.game.mappers.toProtoOperation
-import com.example.domain.game.repositories.Operation
-import com.example.domain.game.repositories.OperationRepository
+import com.example.domain.core.Operation
+import com.example.domain.core.OperationRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map

--- a/data/game/src/main/java/com/example/data/game/GameModule.kt
+++ b/data/game/src/main/java/com/example/data/game/GameModule.kt
@@ -3,8 +3,8 @@ package com.example.data.game
 import com.example.data.core.proto.ProtoStorage
 import com.example.data.core.proto.ProtoStorageFactory
 import com.example.domain.core.GameRepository
+import com.example.domain.core.OperationRepository
 import com.example.domain.game.repositories.GameResultWriter
-import com.example.domain.game.repositories.OperationRepository
 import data.game.ProtoGame
 import org.koin.dsl.module
 

--- a/data/game/src/main/java/com/example/data/game/mappers/ProtoOperationMapper.kt
+++ b/data/game/src/main/java/com/example/data/game/mappers/ProtoOperationMapper.kt
@@ -1,6 +1,6 @@
 package com.example.data.game.mappers
 
-import com.example.domain.game.repositories.Operation
+import com.example.domain.core.Operation
 import data.game.ProtoOperation
 
 fun Operation.toProtoOperation(): ProtoOperation = ProtoOperation

--- a/domain/core/src/main/java/com/example/domain/core/OperationRepository.kt
+++ b/domain/core/src/main/java/com/example/domain/core/OperationRepository.kt
@@ -1,4 +1,4 @@
-package com.example.domain.game.repositories
+package com.example.domain.core
 
 import com.example.sudoku.model.SudokuCellData
 import kotlinx.coroutines.flow.Flow

--- a/domain/creator/src/main/java/com/example/domain/creator/CreateNewGameUseCase.kt
+++ b/domain/creator/src/main/java/com/example/domain/creator/CreateNewGameUseCase.kt
@@ -2,13 +2,15 @@ package com.example.domain.creator
 
 import com.example.domain.core.Game
 import com.example.domain.core.GameDifficulty
+import com.example.domain.core.OperationRepository
 import com.example.domain.core.SudokuGridSize
 import com.example.sudoku.generator.ClassicSudokuGenerator
 import kotlinx.collections.immutable.persistentListOf
 import kotlin.random.Random
 
-class CreateNewGameUseCase {
+class CreateNewGameUseCase(private val operationRepository: OperationRepository) {
 	suspend operator fun invoke(gridSize: SudokuGridSize, difficulty: GameDifficulty): Game {
+		operationRepository.clearOperations()
 		val generator = ClassicSudokuGenerator(gridSize.toInt())
 		val cellsToRemove = calculateCellsToRemove(gridSize, difficulty)
 		val sudokuGrid = generator.createSudoku(cellsToRemove, Random.nextLong())

--- a/domain/creator/src/main/java/com/example/domain/creator/Module.kt
+++ b/domain/creator/src/main/java/com/example/domain/creator/Module.kt
@@ -4,7 +4,7 @@ import org.koin.dsl.module
 
 val domainCreatorModule =
 	module {
-		factory { CreateNewGameUseCase() }
+		factory { CreateNewGameUseCase(get()) }
 		factory { GetSavedGameUseCase(get()) }
 		factory { SaveGameUseCase(get()) }
 		factory { HasActiveGameUseCase(get()) }

--- a/domain/game/src/main/java/com/example/domain/game/usecases/RedoOperationUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/RedoOperationUseCase.kt
@@ -1,6 +1,6 @@
 package com.example.domain.game.usecases
 
-import com.example.domain.game.repositories.OperationRepository
+import com.example.domain.core.OperationRepository
 import com.example.sudoku.model.CellAttributes
 import com.example.sudoku.model.SudokuGrid
 import kotlinx.coroutines.sync.Mutex

--- a/domain/game/src/main/java/com/example/domain/game/usecases/ResetGameUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/ResetGameUseCase.kt
@@ -1,7 +1,7 @@
 package com.example.domain.game.usecases
 
 import com.example.domain.core.Game
-import com.example.domain.game.repositories.OperationRepository
+import com.example.domain.core.OperationRepository
 import com.example.sudoku.model.clearGrid
 import com.example.sudoku.model.clearMatchingNumberHighlight
 import com.example.sudoku.model.clearRowColumnHighlight

--- a/domain/game/src/main/java/com/example/domain/game/usecases/UndoOperationUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/UndoOperationUseCase.kt
@@ -1,6 +1,6 @@
 package com.example.domain.game.usecases
 
-import com.example.domain.game.repositories.OperationRepository
+import com.example.domain.core.OperationRepository
 import com.example.sudoku.model.CellAttributes
 import com.example.sudoku.model.SudokuGrid
 import kotlinx.coroutines.sync.Mutex

--- a/domain/game/src/test/java/com/example/domain/game/usecases/RedoOperationUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/RedoOperationUseCaseTest.kt
@@ -1,7 +1,7 @@
 package com.example.domain.game.usecases
 
-import com.example.domain.game.repositories.Operation
-import com.example.domain.game.repositories.OperationRepository
+import com.example.domain.core.Operation
+import com.example.domain.core.OperationRepository
 import com.example.sudoku.model.CellAttributes
 import com.example.sudoku.model.SudokuCellData
 import com.example.sudoku.model.SudokuGrid

--- a/domain/game/src/test/java/com/example/domain/game/usecases/UndoOperationUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/UndoOperationUseCaseTest.kt
@@ -1,7 +1,7 @@
 package com.example.domain.game.usecases
 
-import com.example.domain.game.repositories.Operation
-import com.example.domain.game.repositories.OperationRepository
+import com.example.domain.core.Operation
+import com.example.domain.core.OperationRepository
 import com.example.sudoku.model.CellAttributes
 import com.example.sudoku.model.SudokuCellData
 import com.example.sudoku.model.SudokuGrid

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -5,13 +5,13 @@ import androidx.lifecycle.viewModelScope
 import com.example.domain.core.Game
 import com.example.domain.core.GameDifficulty
 import com.example.domain.core.GameResult
+import com.example.domain.core.Operation
+import com.example.domain.core.OperationRepository
 import com.example.domain.core.SudokuGridSize
 import com.example.domain.game.ElapsedTimerManager
 import com.example.domain.game.GameManagementUseCases
 import com.example.domain.game.HintUseCases
 import com.example.domain.game.repositories.GameResultWriter
-import com.example.domain.game.repositories.Operation
-import com.example.domain.game.repositories.OperationRepository
 import com.example.domain.game.usecases.GetBestTimeUseCase
 import com.example.domain.game.usecases.RedoOperationUseCase
 import com.example.domain.game.usecases.UndoOperationUseCase
@@ -327,6 +327,7 @@ internal class SudokuGameViewModel(
 						elapsedTime = elapsedTime.value,
 					),
 				)
+				operationRepository.clearOperations()
 			}
 		}
 	}


### PR DESCRIPTION
This pull request refactors the `OperationRepository` and `Operation` classes by moving them from the `domain.game.repositories` package to the more general `domain.core` package. This change consolidates the repository and its related operations into a central location, improving code organization and reusability. Additionally, it updates the relevant classes, use cases, and tests to reflect this refactoring.

### Refactoring of `OperationRepository` and `Operation`:

* [`domain/game/src/main/java/com/example/domain/game/repositories/OperationRepository.kt`](diffhunk://#diff-50fad49989cdfd8107facce9ff27118321353d8e95e0ee10b79902e1d30e2108L1-R1): Moved to `domain/core/src/main/java/com/example/domain/core/OperationRepository.kt` and updated its package declaration.
* Updated imports across multiple files to use the new `domain.core` package for `OperationRepository` and `Operation`. [[1]](diffhunk://#diff-4ccdbdf36e335314b9f4d09f292ee1b90b766295e408526c2c9fae68c88f6ba8L6-R7) [[2]](diffhunk://#diff-9a28baed52925fb95a05ca6ffaa5840768500bcbffde572a97d1cc2e0904f309R6-L7) [[3]](diffhunk://#diff-0e07132cc6cf3d16de783bd0065ff6aafa7d745dc3ed6c03f1de44493efb7f89L3-R3) [[4]](diffhunk://#diff-71a6359f6f938b24339fcdb48c94a34e28d1cb7c31fc381547109d990306a7d0L3-R3) [[5]](diffhunk://#diff-a30f0e24e7d3f6ada472b7ee2db5333f8fa584826ec61c831bfb265d4a373f9eL4-R4) [[6]](diffhunk://#diff-ea067d951e544d9881ecacbed41e3771df819a7402d8e0593c0e982289370406L3-R3) [[7]](diffhunk://#diff-a86ea5e14c0f9ca7ef146b43036e0162b21c4ef2a10a21617ce35923cb4d8325L3-R4) [[8]](diffhunk://#diff-2ce86d9540964cc14eede385a9ec2a8098d5dcdf366a28c2ce8a020157f7880eL3-R4) [[9]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R8-L14)

### Integration of `OperationRepository` into use cases:

* [`domain/creator/src/main/java/com/example/domain/creator/CreateNewGameUseCase.kt`](diffhunk://#diff-155b13e101c1504b12afbba8aa61fc5d0efe424a2324ff49b4d8267193c0ac2cR5-R13): Added `OperationRepository` as a dependency to `CreateNewGameUseCase` and introduced a call to `operationRepository.clearOperations()` in the `invoke` method.
* [`domain/creator/src/main/java/com/example/domain/creator/Module.kt`](diffhunk://#diff-15678f5aab176efe1e1cb07cccf7d64f6fe6999f3ce57b678dcd2c9e5e67e2a9L7-R7): Updated the Koin module to provide `OperationRepository` to `CreateNewGameUseCase`.

### Functional changes in `SudokuGameViewModel`:

* [`feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt`](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R330): Added a call to `operationRepository.clearOperations()` to clear operations when resetting the game state.