### PR TITLE
Feat: add long press functionality to keypad buttons

### DIFF
--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
@@ -250,6 +250,7 @@ private fun SudokuGameScreenContent(
 							GameState.PLAYING -> {
 								KeyPad(
 									onNumberClick = { onEvent(Event.InputNumber(it)) },
+									onNumberLongClick = { onEvent(Event.LongInputNumber(it)) },
 									onClearClick = { onEvent(Event.ClearCell) },
 									onUndoClick = { onEvent(Event.Undo) },
 									onRedoClick = { onEvent(Event.Redo) },
@@ -300,6 +301,7 @@ private fun SudokuGameScreenContent(
 							GameState.PLAYING -> {
 								KeyPad(
 									onNumberClick = { onEvent(Event.InputNumber(it)) },
+									onNumberLongClick = { onEvent(Event.LongInputNumber(it)) },
 									onClearClick = { onEvent(Event.ClearCell) },
 									onUndoClick = { onEvent(Event.Undo) },
 									onRedoClick = { onEvent(Event.Redo) },

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -114,6 +114,8 @@ internal class SudokuGameViewModel(
 
 		data class InputNumber(val number: Int) : Event
 
+		data class LongInputNumber(val number: Int) : Event
+
 		data object SwitchInputMode : Event
 
 		data object ClearCell : Event
@@ -146,6 +148,12 @@ internal class SudokuGameViewModel(
 					selectedCell = _uiState.value.selectedCell,
 					noteMode = _uiState.value.isInNoteMode,
 				)
+
+			is Event.LongInputNumber -> inputNumber(
+				number = event.number,
+				selectedCell = _uiState.value.selectedCell,
+				noteMode = !uiState.value.isInNoteMode,
+			)
 
 			is Event.ClearCell ->
 				inputNumber(

--- a/feature/game/src/main/java/com/example/feature/game/components/KeyPad.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/KeyPad.kt
@@ -43,6 +43,7 @@ import kotlin.math.sqrt
 @Composable
 internal fun KeyPad(
 	onNumberClick: (Int) -> Unit,
+	onNumberLongClick: (Int) -> Unit,
 	onClearClick: () -> Unit,
 	onUndoClick: () -> Unit,
 	onRedoClick: () -> Unit,
@@ -140,6 +141,7 @@ internal fun KeyPad(
 						NumberPad(
 							gridSize = gridSize,
 							onButtonClick = onNumberClick,
+							onButtonLongClick = onNumberLongClick,
 							noteMode = noteMode,
 							textStyle = textStyle,
 							itemSize = itemSize,
@@ -180,6 +182,7 @@ internal fun KeyPad(
 						NumberPad(
 							gridSize = gridSize,
 							onButtonClick = onNumberClick,
+							onButtonLongClick = onNumberLongClick,
 							noteMode = noteMode,
 							textStyle = textStyle,
 							itemSize = itemSize,
@@ -247,6 +250,7 @@ private fun KeyPadPreview() {
 	SudokuSlayerTheme {
 		KeyPad(
 			onNumberClick = { },
+			onNumberLongClick = { },
 			onClearClick = { },
 			onUndoClick = { },
 			onRedoClick = { },
@@ -268,6 +272,7 @@ private fun KeyPadFourPreview() {
 	SudokuSlayerTheme {
 		KeyPad(
 			onNumberClick = { },
+			onNumberLongClick = { },
 			onClearClick = { },
 			onUndoClick = { },
 			onRedoClick = { },
@@ -289,6 +294,7 @@ private fun KeyPadFourLeftHandPreview() {
 	SudokuSlayerTheme {
 		KeyPad(
 			onNumberClick = { },
+			onNumberLongClick = { },
 			onClearClick = { },
 			onUndoClick = { },
 			onRedoClick = { },
@@ -310,6 +316,7 @@ private fun KeyPadSixteenPreview() {
 	SudokuSlayerTheme {
 		KeyPad(
 			onNumberClick = { },
+			onNumberLongClick = { },
 			onClearClick = { },
 			onUndoClick = { },
 			onRedoClick = { },
@@ -331,6 +338,7 @@ private fun KeyPadSixteenLeftPreview() {
 	SudokuSlayerTheme {
 		KeyPad(
 			onNumberClick = { },
+			onNumberLongClick = { },
 			onClearClick = { },
 			onUndoClick = { },
 			onRedoClick = { },

--- a/feature/game/src/main/java/com/example/feature/game/components/keypadparts/KeyPadItem.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/keypadparts/KeyPadItem.kt
@@ -1,7 +1,8 @@
 package com.example.feature.game.components.keypadparts
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,7 +14,9 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,19 +35,27 @@ fun KeyPadItem(
 	text: String,
 	onClick: () -> Unit,
 	modifier: Modifier = Modifier,
+	onLongClick: (() -> Unit)? = null,
 	icon: AppIcon? = null,
 	textStyle: TextStyle = TextStyle(),
 	bgColor: Color = MaterialTheme.colorScheme.primaryContainer,
 	textColor: Color = MaterialTheme.colorScheme.onPrimaryContainer,
 ) {
+	val mutableInteractionSource = remember { MutableInteractionSource() }
 	Box(
 		modifier =
 		modifier
 			.aspectRatio(1f)
 			.clip(CircleShape)
 			.background(bgColor)
-			.clickable(
+			.combinedClickable(
 				onClick = onClick,
+				onLongClick = onLongClick,
+				interactionSource = mutableInteractionSource,
+				indication = ripple(
+					bounded = true,
+					color = textColor.copy(alpha = 0.7f),
+				),
 			),
 		contentAlignment = Alignment.Center,
 	) {
@@ -58,6 +69,7 @@ fun KeyPadItem(
 						modifier = Modifier.size(textStyle.fontSize.value.dp),
 					)
 				}
+
 				is AppIcon.VectorIcon -> {
 					Icon(
 						imageVector = icon.imageVector,

--- a/feature/game/src/main/java/com/example/feature/game/components/keypadparts/NumberPad.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/keypadparts/NumberPad.kt
@@ -26,6 +26,7 @@ import kotlin.math.sqrt
 fun NumberPad(
 	gridSize: Int,
 	onButtonClick: (Int) -> Unit,
+	onButtonLongClick: (Int) -> Unit,
 	noteMode: Boolean,
 	modifier: Modifier = Modifier,
 	itemSize: Dp = 48.dp,
@@ -71,6 +72,7 @@ fun NumberPad(
 					KeyPadItem(
 						text = number.toString(),
 						onClick = { onButtonClick(number) },
+						onLongClick = { onButtonLongClick(number) },
 						bgColor = keyColor,
 						textColor = textColor,
 						textStyle = textStyle,
@@ -89,6 +91,7 @@ private fun NumberPadNineItemsPreview() {
 	SudokuSlayerTheme {
 		NumberPad(
 			onButtonClick = { },
+			onButtonLongClick = { },
 			noteMode = false,
 			gridSize = 9,
 			modifier = Modifier.padding(16.dp),
@@ -102,6 +105,7 @@ private fun NumberPadFourItemsPreview() {
 	SudokuSlayerTheme {
 		NumberPad(
 			onButtonClick = { },
+			onButtonLongClick = { },
 			noteMode = false,
 			gridSize = 4,
 			modifier = Modifier.padding(16.dp),
@@ -115,6 +119,7 @@ private fun NumberPadSixteenItemsPreview() {
 	SudokuSlayerTheme {
 		NumberPad(
 			onButtonClick = { },
+			onButtonLongClick = { },
 			noteMode = false,
 			gridSize = 16,
 			modifier = Modifier.padding(16.dp),


### PR DESCRIPTION
This pull request introduces a new feature to support long-press interactions on the Sudoku keypad, enabling an alternative input mode for numbers. The changes span across multiple files to implement and integrate this functionality, including updates to the `KeyPad`, `NumberPad`, and `SudokuGameViewModel` components.

### Feature Addition: Long-Press Support for Keypad
* **`SudokuGameViewModel` Updates**: Added a new event, `LongInputNumber`, to handle long-press actions. The event toggles the note mode before inputting the number. [[1]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R117-R118) [[2]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R152-R157)
* **`KeyPad` Component Updates**: Introduced a new `onNumberLongClick` callback to handle long-press interactions. Updated the `KeyPad` previews to include this callback. [[1]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R46) [[2]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R144) [[3]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R185) [[4]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R253) [[5]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R275) [[6]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R297) [[7]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R319) [[8]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R341)
* **`NumberPad` Component Updates**: Added an `onButtonLongClick` parameter and updated the `KeyPadItem` integration to support long-press actions. Updated the `NumberPad` previews to include this parameter. [[1]](diffhunk://#diff-a932c1decd05b70d50c0c81dfe2e7f10afbc283a1c4d0fb9d4645d0b7b9c9c7cR29) [[2]](diffhunk://#diff-a932c1decd05b70d50c0c81dfe2e7f10afbc283a1c4d0fb9d4645d0b7b9c9c7cR75) [[3]](diffhunk://#diff-a932c1decd05b70d50c0c81dfe2e7f10afbc283a1c4d0fb9d4645d0b7b9c9c7cR94) [[4]](diffhunk://#diff-a932c1decd05b70d50c0c81dfe2e7f10afbc283a1c4d0fb9d4645d0b7b9c9c7cR108) [[5]](diffhunk://#diff-a932c1decd05b70d50c0c81dfe2e7f10afbc283a1c4d0fb9d4645d0b7b9c9c7cR122)
* **`KeyPadItem` Enhancements**: Replaced the `clickable` modifier with `combinedClickable` to support both click and long-click interactions. Added ripple effects for better visual feedback. [[1]](diffhunk://#diff-6a6d21ccbaef7a7771d81ddf157379d5ead76f0b8dcdbaa4ec86fdf66751fd4fL4-R5) [[2]](diffhunk://#diff-6a6d21ccbaef7a7771d81ddf157379d5ead76f0b8dcdbaa4ec86fdf66751fd4fR17-R19) [[3]](diffhunk://#diff-6a6d21ccbaef7a7771d81ddf157379d5ead76f0b8dcdbaa4ec86fdf66751fd4fR38-R58) [[4]](diffhunk://#diff-6a6d21ccbaef7a7771d81ddf157379d5ead76f0b8dcdbaa4ec86fdf66751fd4fR72)

These changes collectively enhance the user experience by enabling a more intuitive way to toggle note mode while inputting numbers in the Sudoku game.