### PR TITLE
Refactor: modify Operation to support multiple cell changes

### DIFF
--- a/data/game/src/main/java/com/example/data/game/AndroidProtoOperationRepository.kt
+++ b/data/game/src/main/java/com/example/data/game/AndroidProtoOperationRepository.kt
@@ -19,13 +19,15 @@ class AndroidProtoOperationRepository(
 			serializer = serializer,
 		)
 
-	override fun getRedoOperationsFlow(): Flow<List<Operation>> = protoStorage.getData().map {
-		it.redoOperationsList.map { it.toOperation() }
-	}
+	override fun getRedoOperationsFlow(): Flow<List<Operation>> =
+		protoStorage.getData().map { operationHistory ->
+			operationHistory.redoOperationsList.map { it.toOperation() }
+		}
 
-	override fun getUndoOperationsFlow(): Flow<List<Operation>> = protoStorage.getData().map {
-		it.undoOperationsList.map { it.toOperation() }
-	}
+	override fun getUndoOperationsFlow(): Flow<List<Operation>> =
+		protoStorage.getData().map { operationHistory ->
+			operationHistory.undoOperationsList.map { it.toOperation() }
+		}
 
 	override suspend fun getRedoOperations(): List<Operation> =
 		getRedoOperationsFlow().firstOrNull() ?: emptyList()
@@ -34,8 +36,8 @@ class AndroidProtoOperationRepository(
 		getUndoOperationsFlow().firstOrNull() ?: emptyList()
 
 	override suspend fun addRedoOperation(operation: Operation) {
-		require(operation.cell.row == operation.oldCell.row)
-		require(operation.cell.col == operation.oldCell.col)
+		require(operation.changes.all { it.oldCell.row == it.newCell.row })
+		require(operation.changes.all { it.oldCell.col == it.newCell.col })
 
 		protoStorage.updateData {
 			it
@@ -46,8 +48,8 @@ class AndroidProtoOperationRepository(
 	}
 
 	override suspend fun addUndoOperation(operation: Operation) {
-		require(operation.cell.row == operation.oldCell.row)
-		require(operation.cell.col == operation.oldCell.col)
+		require(operation.changes.all { it.oldCell.row == it.newCell.row })
+		require(operation.changes.all { it.oldCell.col == it.newCell.col })
 
 		protoStorage.updateData {
 			it
@@ -58,21 +60,21 @@ class AndroidProtoOperationRepository(
 	}
 
 	override suspend fun removeRedoOperation(id: Long) {
-		protoStorage.updateData {
-			it
+		protoStorage.updateData { operationHistory ->
+			operationHistory
 				.toBuilder()
 				.removeRedoOperations(
-					it.redoOperationsList.indexOfFirst { it.id == id },
+					operationHistory.redoOperationsList.indexOfFirst { it.id == id },
 				).build()
 		}
 	}
 
 	override suspend fun removeUndoOperation(id: Long) {
-		protoStorage.updateData {
-			it
+		protoStorage.updateData { operationHistory ->
+			operationHistory
 				.toBuilder()
 				.removeUndoOperations(
-					it.undoOperationsList.indexOfFirst { it.id == id },
+					operationHistory.undoOperationsList.indexOfFirst { it.id == id },
 				).build()
 		}
 	}

--- a/data/game/src/main/java/com/example/data/game/mappers/ProtoOperationMapper.kt
+++ b/data/game/src/main/java/com/example/data/game/mappers/ProtoOperationMapper.kt
@@ -1,17 +1,28 @@
 package com.example.data.game.mappers
 
+import com.example.domain.core.CellChange
 import com.example.domain.core.Operation
+import data.game.ProtoCellChange
 import data.game.ProtoOperation
 
-fun Operation.toProtoOperation(): ProtoOperation = ProtoOperation
+internal fun Operation.toProtoOperation(): ProtoOperation = ProtoOperation
 	.newBuilder()
 	.setId(id)
-	.setCell(cell.toProtoCell())
-	.setOldCell(oldCell.toProtoCell())
+	.addAllChanges(changes.map { it.toProtoCellChange() })
 	.build()
 
-fun ProtoOperation.toOperation(): Operation = Operation(
+internal fun ProtoOperation.toOperation(): Operation = Operation(
 	id = id,
-	cell = cell.toSudokuCellData(),
-	oldCell = oldCell.toSudokuCellData(),
+	changes = changesList.map { it.toCellChange() },
 )
+
+internal fun ProtoCellChange.toCellChange(): CellChange = com.example.domain.core.CellChange(
+	oldCell = oldCell.toSudokuCellData(),
+	newCell = newCell.toSudokuCellData(),
+)
+
+internal fun CellChange.toProtoCellChange(): ProtoCellChange = ProtoCellChange
+	.newBuilder()
+	.setOldCell(oldCell.toProtoCell())
+	.setNewCell(newCell.toProtoCell())
+	.build()

--- a/data/game/src/main/proto/ProtoOperation.proto
+++ b/data/game/src/main/proto/ProtoOperation.proto
@@ -7,8 +7,12 @@ option java_multiple_files = true;
 
 message ProtoOperation {
 	int64 id = 1;
-	ProtoCell cell = 4;
-	ProtoCell oldCell = 5;
+	repeated ProtoCellChange changes = 2;
+}
+
+message ProtoCellChange {
+	ProtoCell oldCell = 1;
+	ProtoCell newCell = 2;
 }
 
 message ProtoOperationHistory {

--- a/domain/core/src/main/java/com/example/domain/core/OperationRepository.kt
+++ b/domain/core/src/main/java/com/example/domain/core/OperationRepository.kt
@@ -31,4 +31,16 @@ interface OperationRepository {
 	suspend fun findUndoOperation(id: Long): Operation?
 }
 
-data class Operation(val id: Long, val cell: SudokuCellData, val oldCell: SudokuCellData)
+data class Operation(val id: Long, val changes: List<CellChange>) {
+	constructor(id: Long, vararg changes: CellChange) : this(id, changes.toList())
+}
+
+/**
+ * Represents a change to a Sudoku cell.
+ * The first element is the old value, and the second element is the new value.
+ * @property oldCell The old value of the cell.
+ * @property newCell The new value of the cell.
+ */
+data class CellChange(val oldCell: SudokuCellData, val newCell: SudokuCellData)
+
+infix fun SudokuCellData.changedTo(newCell: SudokuCellData) = CellChange(this, newCell)

--- a/domain/game/src/main/java/com/example/domain/game/usecases/RedoOperationUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/RedoOperationUseCase.kt
@@ -59,7 +59,7 @@ class RedoOperationUseCase(
 						}
 					} else {
 						updatedGrid = inputNumberUseCase(
-							sudokuGrid = grid,
+							sudokuGrid = updatedGrid,
 							number = newCell.number,
 							row = newCell.row,
 							column = newCell.col,

--- a/domain/game/src/main/java/com/example/domain/game/usecases/RedoOperationUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/RedoOperationUseCase.kt
@@ -37,35 +37,38 @@ class RedoOperationUseCase(
 				}
 
 				var updatedGrid = grid
-				val oldCell = lastOperation.oldCell
-				val newCell = lastOperation.cell
-				val symmetricDifference =
-					(oldCell.cornerNotes - newCell.cornerNotes) union
-						(newCell.cornerNotes - oldCell.cornerNotes)
+				lastOperation.changes.forEach { change ->
+					val oldCell = change.oldCell
+					val newCell = change.newCell
+					val symmetricDifference =
+						(oldCell.cornerNotes - newCell.cornerNotes) union
+							(newCell.cornerNotes - oldCell.cornerNotes)
 
-				val isNote = symmetricDifference.isNotEmpty() && newCell.number == 0
-				return if (isNote) {
-					symmetricDifference.forEach { noteVaule ->
+					val isNote = symmetricDifference.isNotEmpty() && newCell.number == 0
+
+					if (isNote) {
+						symmetricDifference.forEach { noteVaule ->
+							updatedGrid = inputNumberUseCase(
+								sudokuGrid = updatedGrid,
+								number = noteVaule,
+								row = newCell.row,
+								column = newCell.col,
+								isNote = true,
+								isHint = newCell.attributes.contains(element = CellAttributes.HINT_REVEALED),
+							)
+						}
+					} else {
 						updatedGrid = inputNumberUseCase(
-							sudokuGrid = updatedGrid,
-							number = noteVaule,
+							sudokuGrid = grid,
+							number = newCell.number,
 							row = newCell.row,
 							column = newCell.col,
-							isNote = true,
-							isHint = newCell.attributes.contains(element = CellAttributes.HINT_REVEALED),
+							isNote = false,
+							isHint = newCell.attributes.contains(CellAttributes.HINT_REVEALED),
 						)
 					}
-					updatedGrid
-				} else {
-					inputNumberUseCase(
-						sudokuGrid = grid,
-						number = newCell.number,
-						row = newCell.row,
-						column = newCell.col,
-						isNote = false,
-						isHint = newCell.attributes.contains(CellAttributes.HINT_REVEALED),
-					)
 				}
+				return updatedGrid
 			}
 		} finally {
 			isProcessing.set(false)

--- a/domain/game/src/main/java/com/example/domain/game/usecases/UndoOperationUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/UndoOperationUseCase.kt
@@ -36,35 +36,37 @@ class UndoOperationUseCase(
 				}
 
 				var updatedGrid = grid
-				val oldCell = lastOperation.oldCell
-				val newCell = lastOperation.cell
-				val symmetricDifference =
-					(oldCell.cornerNotes - newCell.cornerNotes) union
-						(newCell.cornerNotes - oldCell.cornerNotes)
-
-				val isNote = symmetricDifference.isNotEmpty() && oldCell.number == 0
-				return if (isNote) {
-					symmetricDifference.forEach { noteVaule ->
+				lastOperation.changes.forEach { change ->
+					val oldCell = change.oldCell
+					val newCell = change.newCell
+					val symmetricDifference =
+						(oldCell.cornerNotes - newCell.cornerNotes) union
+							(newCell.cornerNotes - oldCell.cornerNotes)
+					val isNote = symmetricDifference.isNotEmpty() && oldCell.number == 0
+					if (isNote) {
+						symmetricDifference.forEach { noteVaule ->
+							updatedGrid = inputNumberUseCase(
+								sudokuGrid = updatedGrid,
+								number = noteVaule,
+								row = oldCell.row,
+								column = oldCell.col,
+								isNote = true,
+								isHint = oldCell.attributes.contains(element = CellAttributes.HINT_REVEALED),
+							)
+						}
+					} else {
 						updatedGrid = inputNumberUseCase(
-							sudokuGrid = updatedGrid,
-							number = noteVaule,
+							sudokuGrid = grid,
+							number = oldCell.number,
 							row = oldCell.row,
 							column = oldCell.col,
-							isNote = true,
-							isHint = oldCell.attributes.contains(element = CellAttributes.HINT_REVEALED),
+							isNote = false,
+							isHint = oldCell.attributes.contains(CellAttributes.HINT_REVEALED),
 						)
 					}
-					updatedGrid
-				} else {
-					inputNumberUseCase(
-						sudokuGrid = grid,
-						number = oldCell.number,
-						row = oldCell.row,
-						column = oldCell.col,
-						isNote = false,
-						isHint = oldCell.attributes.contains(CellAttributes.HINT_REVEALED),
-					)
 				}
+
+				return updatedGrid
 			}
 		} finally {
 			isProcessing.set(false)

--- a/domain/game/src/main/java/com/example/domain/game/usecases/UndoOperationUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/UndoOperationUseCase.kt
@@ -56,7 +56,7 @@ class UndoOperationUseCase(
 						}
 					} else {
 						updatedGrid = inputNumberUseCase(
-							sudokuGrid = grid,
+							sudokuGrid = updatedGrid,
 							number = oldCell.number,
 							row = oldCell.row,
 							column = oldCell.col,

--- a/domain/game/src/test/java/com/example/domain/game/usecases/RedoOperationUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/RedoOperationUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.example.domain.game.usecases
 
 import com.example.domain.core.Operation
 import com.example.domain.core.OperationRepository
+import com.example.domain.core.changedTo
 import com.example.sudoku.model.CellAttributes
 import com.example.sudoku.model.SudokuCellData
 import com.example.sudoku.model.SudokuGrid
@@ -85,7 +86,7 @@ class RedoOperationUseCaseTest {
 		// Test a successful redo operation where the last operation was a number input (isNote is false).
 		val oldCell = SudokuCellData(0, 0, 0)
 		val newCell = SudokuCellData(0, 0, 5)
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 
 		val result = redoOperationUseCase(initialGrid)
@@ -108,7 +109,7 @@ class RedoOperationUseCaseTest {
 		// Test a successful redo operation where the last operation was adding a single note.
 		val oldCell = SudokuCellData(0, 0, 0, cornerNotes = persistentSetOf(1))
 		val newCell = SudokuCellData(0, 0, 0, cornerNotes = persistentSetOf(1, 2))
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 
 		val result = redoOperationUseCase(initialGrid)
@@ -131,7 +132,7 @@ class RedoOperationUseCaseTest {
 		// Test that when a note is placed on a cell with number, redoing brings the notes back.
 		val oldCell = SudokuCellData(0, 0, 5, cornerNotes = persistentSetOf())
 		val newCell = SudokuCellData(0, 0, 0, cornerNotes = persistentSetOf(1, 2))
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		val gridAfterNote1 = SudokuGrid().withValue(0, 0, 1) // Dummy grid
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 		coEvery { inputNumberUseCase(any(), 1, any(), any(), true, any()) } returns gridAfterNote1
@@ -152,7 +153,7 @@ class RedoOperationUseCaseTest {
 			SudokuCellData(0, 0, 0, attributes = persistentSetOf(CellAttributes.HINT_REVEALED))
 		val newCell =
 			SudokuCellData(0, 0, 5, attributes = persistentSetOf(CellAttributes.HINT_REVEALED))
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 
 		redoOperationUseCase(initialGrid)
@@ -174,7 +175,7 @@ class RedoOperationUseCaseTest {
 		// Verify that `addUndoOperation`, `findRedoOperation`, and `removeRedoOperation` are called correctly.
 		val oldCell = SudokuCellData(0, 0, 0)
 		val newCell = SudokuCellData(0, 0, 5)
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 		coEvery { operationRepository.findRedoOperation(lastOperation.id) } returns lastOperation
 
@@ -190,7 +191,7 @@ class RedoOperationUseCaseTest {
 		// Test that if `findRedoOperation` returns null, `removeRedoOperation` is not called.
 		val oldCell = SudokuCellData(0, 0, 0)
 		val newCell = SudokuCellData(0, 0, 5)
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 		coEvery { operationRepository.findRedoOperation(lastOperation.id) } returns null
 
@@ -206,7 +207,7 @@ class RedoOperationUseCaseTest {
 		// Test that the critical section of the code is properly protected by the mutex.
 		val oldCell = SudokuCellData(0, 0, 0)
 		val newCell = SudokuCellData(0, 0, 5)
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 
 		redoOperationUseCase(initialGrid)
@@ -256,7 +257,7 @@ class RedoOperationUseCaseTest {
 
 	@Test
 	fun `RedoOperationUseCase exception in addUndoOperation`() = runTest {
-		val lastOperation = Operation(1, SudokuCellData(0, 0, 5), SudokuCellData(0, 0, 0))
+		val lastOperation = Operation(1, SudokuCellData(0, 0, 5) changedTo SudokuCellData(0, 0, 0))
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 		testExceptionHandling {
 			coEvery { operationRepository.addUndoOperation(any()) } throws RuntimeException("DB error")
@@ -265,7 +266,7 @@ class RedoOperationUseCaseTest {
 
 	@Test
 	fun `RedoOperationUseCase exception in findRedoOperation`() = runTest {
-		val lastOperation = Operation(1, SudokuCellData(0, 0, 5), SudokuCellData(0, 0, 0))
+		val lastOperation = Operation(1, SudokuCellData(0, 0, 5) changedTo SudokuCellData(0, 0, 0))
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 		testExceptionHandling {
 			coEvery { operationRepository.findRedoOperation(any()) } throws RuntimeException("DB error")
@@ -274,7 +275,7 @@ class RedoOperationUseCaseTest {
 
 	@Test
 	fun `RedoOperationUseCase exception in removeRedoOperation`() = runTest {
-		val lastOperation = Operation(1, SudokuCellData(0, 0, 5), SudokuCellData(0, 0, 0))
+		val lastOperation = Operation(1, SudokuCellData(0, 0, 5) changedTo SudokuCellData(0, 0, 0))
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 		testExceptionHandling {
 			coEvery { operationRepository.removeRedoOperation(any()) } throws RuntimeException("DB error")
@@ -283,7 +284,7 @@ class RedoOperationUseCaseTest {
 
 	@Test
 	fun `RedoOperationUseCase exception in inputNumberUseCase`() = runTest {
-		val lastOperation = Operation(1, SudokuCellData(0, 0, 5), SudokuCellData(0, 0, 0))
+		val lastOperation = Operation(1, SudokuCellData(0, 0, 5) changedTo SudokuCellData(0, 0, 0))
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 		testExceptionHandling {
 			coEvery {

--- a/domain/game/src/test/java/com/example/domain/game/usecases/UndoOperationUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/UndoOperationUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.example.domain.game.usecases
 
 import com.example.domain.core.Operation
 import com.example.domain.core.OperationRepository
+import com.example.domain.core.changedTo
 import com.example.sudoku.model.CellAttributes
 import com.example.sudoku.model.SudokuCellData
 import com.example.sudoku.model.SudokuGrid
@@ -86,7 +87,7 @@ class UndoOperationUseCaseTest {
 		// Verify `inputNumberUseCase` is called with correct parameters and the updated grid is returned.
 		val oldCell = SudokuCellData(0, 0, 0)
 		val newCell = SudokuCellData(0, 0, 5)
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 
 		val result = undoOperationUseCase(initialGrid)
@@ -110,7 +111,7 @@ class UndoOperationUseCaseTest {
 		// Verify `inputNumberUseCase` is called once with correct parameters and the updated grid is returned.
 		val oldCell = SudokuCellData(0, 0, 0, cornerNotes = persistentSetOf(1))
 		val newCell = SudokuCellData(0, 0, 0, cornerNotes = persistentSetOf(1, 2))
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 
 		val result = undoOperationUseCase(initialGrid)
@@ -134,7 +135,7 @@ class UndoOperationUseCaseTest {
 		// Verify `inputNumberUseCase` is called for each differing note and the final updated grid is returned.
 		val oldCell = SudokuCellData(0, 0, 0, cornerNotes = persistentSetOf(1))
 		val newCell = SudokuCellData(0, 0, 0, cornerNotes = persistentSetOf(1, 2, 3))
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		val gridAfterNote2 = SudokuGrid().withValue(0, 0, 2)
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 		coEvery { inputNumberUseCase(any(), 2, any(), any(), true, any()) } returns gridAfterNote2
@@ -152,7 +153,7 @@ class UndoOperationUseCaseTest {
 		// Test that when a number is placed on a cell with notes, undoing brings the notes back.
 		val oldCell = SudokuCellData(0, 0, 0, cornerNotes = persistentSetOf(1, 2))
 		val newCell = SudokuCellData(0, 0, 5, cornerNotes = persistentSetOf())
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		val gridAfterNote1 = SudokuGrid().withValue(0, 0, 1) // Dummy grid
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 		coEvery {
@@ -181,7 +182,7 @@ class UndoOperationUseCaseTest {
 			SudokuCellData(0, 0, 0, attributes = persistentSetOf(CellAttributes.HINT_REVEALED))
 		val newCell =
 			SudokuCellData(0, 0, 5, attributes = persistentSetOf(CellAttributes.HINT_REVEALED))
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 
 		undoOperationUseCase(initialGrid)
@@ -203,7 +204,7 @@ class UndoOperationUseCaseTest {
 		// Test that when undoing an operation on a cell that was not hint-revealed, the `isHint` parameter is correctly passed as false to `inputNumberUseCase`.
 		val oldCell = SudokuCellData(0, 0, 0)
 		val newCell = SudokuCellData(0, 0, 5)
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 
 		undoOperationUseCase(initialGrid)
@@ -225,7 +226,7 @@ class UndoOperationUseCaseTest {
 		// Verify that `operationRepository.addRedoOperation` and `operationRepository.removeUndoOperation` are called with the correct arguments during a successful undo.
 		val oldCell = SudokuCellData(0, 0, 0)
 		val newCell = SudokuCellData(0, 0, 5)
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 		coEvery { operationRepository.findUndoOperation(lastOperation.id) } returns lastOperation
 
@@ -240,7 +241,7 @@ class UndoOperationUseCaseTest {
 		// Test that the critical section of the code is properly protected by the mutex
 		val oldCell = SudokuCellData(0, 0, 0)
 		val newCell = SudokuCellData(0, 0, 5)
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 
 		undoOperationUseCase(initialGrid)
@@ -294,7 +295,7 @@ class UndoOperationUseCaseTest {
 	fun `UndoOperationUseCase exception in addRedoOperation`() = runTest {
 		// Test how the use case handles an exception thrown by `operationRepository.addRedoOperation()`.
 		// Ensure `isProcessing` is reset.
-		val lastOperation = Operation(1, SudokuCellData(0, 0, 5), SudokuCellData(0, 0, 0))
+		val lastOperation = Operation(1, SudokuCellData(0, 0, 5) changedTo SudokuCellData(0, 0, 0))
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 		testExceptionHandling {
 			coEvery { operationRepository.addRedoOperation(any()) } throws RuntimeException("DB error")
@@ -305,7 +306,7 @@ class UndoOperationUseCaseTest {
 	fun `UndoOperationUseCase exception in findUndoOperation`() = runTest {
 		// Test how the use case handles an exception thrown by `operationRepository.findUndoOperation()`.
 		// Ensure `isProcessing` is reset.
-		val lastOperation = Operation(1, SudokuCellData(0, 0, 5), SudokuCellData(0, 0, 0))
+		val lastOperation = Operation(1, SudokuCellData(0, 0, 5) changedTo SudokuCellData(0, 0, 0))
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 		testExceptionHandling {
 			coEvery { operationRepository.findUndoOperation(any()) } throws RuntimeException("DB error")
@@ -316,7 +317,7 @@ class UndoOperationUseCaseTest {
 	fun `UndoOperationUseCase exception in removeUndoOperation`() = runTest {
 		// Test how the use case handles an exception thrown by `operationRepository.removeUndoOperation()`.
 		// Ensure `isProcessing` is reset.
-		val lastOperation = Operation(1, SudokuCellData(0, 0, 5), SudokuCellData(0, 0, 0))
+		val lastOperation = Operation(1, SudokuCellData(0, 0, 5) changedTo SudokuCellData(0, 0, 0))
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 		testExceptionHandling {
 			coEvery { operationRepository.removeUndoOperation(any()) } throws RuntimeException("DB error")
@@ -329,7 +330,7 @@ class UndoOperationUseCaseTest {
 		// Ensure `isProcessing` is reset.
 		val oldCell = SudokuCellData(0, 0, 0, cornerNotes = persistentSetOf(1))
 		val newCell = SudokuCellData(0, 0, 0, cornerNotes = persistentSetOf(1, 2))
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 		testExceptionHandling {
 			coEvery {
@@ -349,7 +350,7 @@ class UndoOperationUseCaseTest {
 	fun `UndoOperationUseCase exception in inputNumberUseCase number input `() = runTest {
 		// Test how the use case handles an exception thrown by `inputNumberUseCase` when `isNote` is false.
 		// Ensure `isProcessing` is reset.
-		val lastOperation = Operation(1, SudokuCellData(0, 0, 5), SudokuCellData(0, 0, 0))
+		val lastOperation = Operation(1, SudokuCellData(0, 0, 5) changedTo SudokuCellData(0, 0, 0))
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 		testExceptionHandling {
 			coEvery {
@@ -372,7 +373,7 @@ class UndoOperationUseCaseTest {
 			// This should trigger the `else` branch for number input.
 			val oldCell = SudokuCellData(0, 0, 0, cornerNotes = persistentSetOf(1))
 			val newCell = SudokuCellData(0, 0, 5, cornerNotes = persistentSetOf(1))
-			val lastOperation = Operation(1, newCell, oldCell)
+			val lastOperation = Operation(1, oldCell changedTo newCell)
 			coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 
 			undoOperationUseCase(initialGrid)
@@ -387,7 +388,7 @@ class UndoOperationUseCaseTest {
 			// This should also trigger the `else` branch for number input, effectively undoing a number placement that might have also involved notes.
 			val oldCell = SudokuCellData(0, 0, 9, cornerNotes = persistentSetOf(1))
 			val newCell = SudokuCellData(0, 0, 9, cornerNotes = persistentSetOf(1, 2))
-			val lastOperation = Operation(1, newCell, oldCell)
+			val lastOperation = Operation(1, oldCell changedTo newCell)
 			coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 
 			undoOperationUseCase(initialGrid)
@@ -410,7 +411,7 @@ class UndoOperationUseCaseTest {
 		// This implies undoing an empty cell to an empty cell, should fall into the else branch and input 0.
 		val oldCell = SudokuCellData(0, 0, 0)
 		val newCell = SudokuCellData(0, 0, 5)
-		val lastOperation = Operation(1, newCell, oldCell)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
 		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
 
 		undoOperationUseCase(initialGrid)

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -2,6 +2,7 @@ package com.example.feature.game
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.domain.core.CellChange
 import com.example.domain.core.Game
 import com.example.domain.core.GameDifficulty
 import com.example.domain.core.GameResult
@@ -262,8 +263,12 @@ internal class SudokuGameViewModel(
 				addUndoOperation(
 					Operation(
 						id = operationRepository.getUndoOperations().size.toLong(),
-						cell = updatedSudoku.getCellAt(row, col),
-						oldCell = backupCell,
+						changes = listOf(
+							CellChange(
+								oldCell = backupCell,
+								newCell = updatedSudoku.getCellAt(row, col),
+							),
+						),
 					),
 				)
 				clearRedoOperations()


### PR DESCRIPTION
This commit refactors the `Operation` data class to support multiple cell changes within a single operation. This is achieved by replacing the `cell` and `oldCell` properties with a list of `CellChange` objects.

**Key Changes:**

- **Domain Layer (`domain/core`):**
    - `Operation` now holds a `List<CellChange>` instead of single `cell` and `oldCell` `SudokuCellData` instances.
    - Introduced a new data class `CellChange(oldCell: SudokuCellData, newCell: SudokuCellData)` to represent a single cell modification.
    - Added an infix extension function `SudokuCellData.changedTo(newCell: SudokuCellData)` for creating `CellChange` instances more expressively.
- **Data Layer (`data/game`):**
    - **`ProtoOperation.proto`:** - `ProtoOperation` message now contains a `repeated ProtoCellChange changes` field instead of `ProtoCell cell` and `ProtoCell oldCell`. - Added a new `ProtoCellChange` message with `ProtoCell oldCell` and `ProtoCell newCell` fields.
    - **`ProtoOperationMapper.kt`:**
        - Updated mappers `toProtoOperation()` and `toOperation()` to handle the new structure with `List<CellChange>` and `repeated ProtoCellChange`.
        - Added new mappers `toProtoCellChange()` and `toCellChange()`.
    - **`AndroidProtoOperationRepository.kt`:** - Updated `addRedoOperation` and `addUndoOperation` to validate that all `CellChange` objects within an operation refer to the same cell coordinates. - Modified stream mapping and update logic to correctly handle the list of changes.
- **Use Cases (`domain/game`):**
    - `UndoOperationUseCase.kt` and `RedoOperationUseCase.kt`: - Updated logic to iterate over the `changes` list in an `Operation`. - The core logic for determining if a change is a note or number input and calling `inputNumberUseCase` remains similar but is now applied to each `CellChange` in the list.
- **ViewModel (`feature/game`):**
    - `SudokuGameViewModel.kt`: - When adding an undo operation after a number input, it now creates an `Operation` with a single `CellChange` in the `changes` list.
- **Tests:**
    - Updated unit tests for `RedoOperationUseCaseTest.kt` and `UndoOperationUseCaseTest.kt` to reflect the new `Operation` structure, using the `changedTo` infix function for creating `CellChange` instances within test operations.

This change provides more flexibility for representing complex operations that might affect multiple aspects of a cell or potentially multiple cells simultaneously in the future, although the current implementation primarily uses it for single cell changes.