### PR TITLE
Feat/auto clear notes

### DIFF
--- a/data/settings/src/main/java/com/example/data/settings/AndroidSettingsRepository.kt
+++ b/data/settings/src/main/java/com/example/data/settings/AndroidSettingsRepository.kt
@@ -44,6 +44,10 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 		SettingsPreferenceKeys.InsightsSummaryCompactLayout,
 	).map { it == true }
 
+	override val autoClearNotes: Flow<Boolean> = preferenceStorage.getAsFlow(
+		SettingsPreferenceKeys.AutoClearNotes,
+	).map { it == true }
+
 	override suspend fun setDarkMode(darkMode: DarkMode) {
 		preferenceStorage.set(SettingsPreferenceKeys.DarkMode, darkMode.displayName)
 	}
@@ -70,6 +74,10 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 
 	override suspend fun setInsightsSummaryCompactLayout(compactLayout: Boolean) {
 		preferenceStorage.set(SettingsPreferenceKeys.InsightsSummaryCompactLayout, compactLayout)
+	}
+
+	override suspend fun setAutoClearNotes(autoClearNotes: Boolean) {
+		preferenceStorage.set(SettingsPreferenceKeys.AutoClearNotes, autoClearNotes)
 	}
 
 	override fun getAvailableColorSchemes(): List<String> = ColorScheme.getAvailableColorSchemes()

--- a/data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.kt
+++ b/data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.kt
@@ -3,7 +3,8 @@ package com.example.data.settings
 import com.example.data.core.preferences.PreferenceStorage
 
 interface SettingsPreferenceKeys {
-	data object DarkMode : PreferenceStorage.Key.StringKey(name = "dark_mode", defaultValue = "system")
+	data object DarkMode :
+		PreferenceStorage.Key.StringKey(name = "dark_mode", defaultValue = "system")
 
 	data object DarkColorScheme : PreferenceStorage.Key.StringKey(
 		name = "dark_scheme",
@@ -15,7 +16,8 @@ interface SettingsPreferenceKeys {
 		defaultValue = "latte",
 	)
 
-	data object Language : PreferenceStorage.Key.StringKey(name = "language", defaultValue = "system")
+	data object Language :
+		PreferenceStorage.Key.StringKey(name = "language", defaultValue = "system")
 
 	data object LeftHandMode : PreferenceStorage.Key.BooleanKey(
 		name = "left_hand_mode",
@@ -29,6 +31,11 @@ interface SettingsPreferenceKeys {
 
 	data object InsightsSummaryCompactLayout : PreferenceStorage.Key.BooleanKey(
 		name = "insights_summary_compact_layout",
+		defaultValue = true,
+	)
+
+	data object AutoClearNotes : PreferenceStorage.Key.BooleanKey(
+		name = "auto_clear_notes",
 		defaultValue = true,
 	)
 }

--- a/domain/game/src/main/java/com/example/domain/game/GameManagementUseCases.kt
+++ b/domain/game/src/main/java/com/example/domain/game/GameManagementUseCases.kt
@@ -1,5 +1,6 @@
 package com.example.domain.game
 
+import com.example.domain.game.usecases.AutoClearNotesUseCase
 import com.example.domain.game.usecases.ClearActiveGameUseCase
 import com.example.domain.game.usecases.FocusOnHintCellsUseCase
 import com.example.domain.game.usecases.GenerateHintLogUseCase
@@ -19,6 +20,7 @@ data class GameManagementUseCases(
 	val inputNumber: InputNumberUseCase,
 	val resetGame: ResetGameUseCase,
 	val clearActiveGame: ClearActiveGameUseCase,
+	val autoClearNotes: AutoClearNotesUseCase,
 )
 
 data class HintUseCases(

--- a/domain/game/src/main/java/com/example/domain/game/GameUpdate.kt
+++ b/domain/game/src/main/java/com/example/domain/game/GameUpdate.kt
@@ -1,0 +1,12 @@
+package com.example.domain.game
+
+import com.example.domain.core.CellChange
+import com.example.sudoku.model.SudokuGrid
+
+/**
+ * Represents the result of an operation that modifies the game state.
+ *
+ * @property resultingGrid The new state of the Sudoku grid after the operation.
+ * @property changes A list of the specific, reversible operations that were performed.
+ */
+data class GameUpdate(val resultingGrid: SudokuGrid, val changes: List<CellChange>)

--- a/domain/game/src/main/java/com/example/domain/game/Module.kt
+++ b/domain/game/src/main/java/com/example/domain/game/Module.kt
@@ -1,5 +1,6 @@
 package com.example.domain.game
 
+import com.example.domain.game.usecases.AutoClearNotesUseCase
 import com.example.domain.game.usecases.ClearActiveGameUseCase
 import com.example.domain.game.usecases.ClearHighlightedNumbersUseCase
 import com.example.domain.game.usecases.ClearHighlightedRowAndColumnUseCase
@@ -42,6 +43,7 @@ val domainGameModule =
 
 		factory { InputNumberUseCase() }
 		factory { ResetGameUseCase(get()) }
+		factory { AutoClearNotesUseCase() }
 
 		factory { ProvideHintUseCase(get()) }
 		factory { FocusOnHintCellsUseCase() }
@@ -70,6 +72,7 @@ val domainGameModule =
 				inputNumber = get(),
 				resetGame = get(),
 				clearActiveGame = get(),
+				autoClearNotes = get(),
 			)
 		}
 	}

--- a/domain/game/src/main/java/com/example/domain/game/usecases/AutoClearNotesUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/AutoClearNotesUseCase.kt
@@ -1,0 +1,63 @@
+package com.example.domain.game.usecases
+
+import com.example.domain.core.CellChange
+import com.example.domain.core.changedTo
+import com.example.domain.game.GameUpdate
+import com.example.sudoku.model.SudokuGrid
+import kotlinx.collections.immutable.minus
+
+class AutoClearNotesUseCase {
+	operator fun invoke(sudokuGrid: SudokuGrid, row: Int, column: Int, number: Int): GameUpdate {
+		if (number == 0) return GameUpdate(sudokuGrid, emptyList())
+
+		var result = sudokuGrid
+		val cellChanges = mutableListOf<CellChange>()
+		for (i in 0 until sudokuGrid.gridSize) {
+			// Same column
+			if (i != row && result.getCellAt(i, column).cornerNotes.contains(number)) {
+				val oldCell = result.getCellAt(i, column)
+				val newCell = oldCell.copy(cornerNotes = oldCell.cornerNotes - number)
+				result = result.withReplacedCell(
+					row = i,
+					col = column,
+					cellData = newCell,
+				)
+				cellChanges.add(oldCell changedTo newCell)
+			}
+			// Same row
+			if (i != column && result.getCellAt(row, i).cornerNotes.contains(number)) {
+				val oldCell = result.getCellAt(row, i)
+				val newCell = oldCell.copy(cornerNotes = oldCell.cornerNotes - number)
+				result = result.withReplacedCell(
+					row = row,
+					col = i,
+					cellData = newCell,
+				)
+				cellChanges.add(oldCell changedTo newCell)
+			}
+
+			// Same block
+			val subgridSize = result.subgridSize
+			result.data.filter {
+				(it.row / subgridSize) * subgridSize + it.col / subgridSize ==
+					(row / subgridSize) * subgridSize + column / subgridSize &&
+					it.row != row &&
+					it.col != column &&
+					it.number == 0 &&
+					it.cornerNotes.contains(number)
+			}.forEach { oldCell ->
+				val newCell = oldCell.copy(cornerNotes = oldCell.cornerNotes - number)
+				result = result.withReplacedCell(
+					row = oldCell.row,
+					col = oldCell.col,
+					cellData = newCell,
+				)
+				cellChanges.add(oldCell changedTo newCell)
+			}
+		}
+		return GameUpdate(
+			resultingGrid = result,
+			changes = cellChanges,
+		)
+	}
+}

--- a/domain/game/src/main/java/com/example/domain/game/usecases/AutoClearNotesUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/AutoClearNotesUseCase.kt
@@ -35,26 +35,27 @@ class AutoClearNotesUseCase {
 				)
 				cellChanges.add(oldCell changedTo newCell)
 			}
-
-			// Same block
-			val subgridSize = result.subgridSize
-			result.data.filter {
-				(it.row / subgridSize) * subgridSize + it.col / subgridSize ==
-					(row / subgridSize) * subgridSize + column / subgridSize &&
-					it.row != row &&
-					it.col != column &&
-					it.number == 0 &&
-					it.cornerNotes.contains(number)
-			}.forEach { oldCell ->
-				val newCell = oldCell.copy(cornerNotes = oldCell.cornerNotes - number)
-				result = result.withReplacedCell(
-					row = oldCell.row,
-					col = oldCell.col,
-					cellData = newCell,
-				)
-				cellChanges.add(oldCell changedTo newCell)
-			}
 		}
+
+		// Same block
+		val subgridSize = result.subgridSize
+		result.data.filter {
+			(it.row / subgridSize) * subgridSize + it.col / subgridSize ==
+				(row / subgridSize) * subgridSize + column / subgridSize &&
+				it.row != row &&
+				it.col != column &&
+				it.number == 0 &&
+				it.cornerNotes.contains(number)
+		}.forEach { oldCell ->
+			val newCell = oldCell.copy(cornerNotes = oldCell.cornerNotes - number)
+			result = result.withReplacedCell(
+				row = oldCell.row,
+				col = oldCell.col,
+				cellData = newCell,
+			)
+			cellChanges.add(oldCell changedTo newCell)
+		}
+
 		return GameUpdate(
 			resultingGrid = result,
 			changes = cellChanges,

--- a/domain/game/src/test/java/com/example/domain/game/usecases/AutoClearNotesUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/AutoClearNotesUseCaseTest.kt
@@ -1,0 +1,350 @@
+package com.example.domain.game.usecases
+
+import com.example.sudoku.model.SudokuCellData
+import com.example.sudoku.model.SudokuGrid
+import kotlinx.collections.immutable.persistentSetOf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AutoClearNotesUseCaseTest {
+	private val autoClearNotesUseCase = AutoClearNotesUseCase()
+
+	@Test
+	fun `Test with number 0`() {
+		// Test if the function returns the original SudokuGrid when the input number is 0.
+		val grid = SudokuGrid().withValue(0, 0, 1)
+		val result = autoClearNotesUseCase(grid, 0, 0, 0).resultingGrid
+		assert(result == grid)
+	}
+
+	@Test
+	fun `Test with a number not present in any corner notes`() {
+		// Test if the function returns the original SudokuGrid when the input number is not present in any corner notes of the relevant cells (same row, column, or block).
+		val grid = SudokuGrid()
+			.withReplacedCell(0, 1, SudokuCellData(0, 1, cornerNotes = persistentSetOf(2, 3)))
+			.withReplacedCell(1, 0, SudokuCellData(1, 0, cornerNotes = persistentSetOf(4, 5)))
+			.withReplacedCell(1, 1, SudokuCellData(1, 1, cornerNotes = persistentSetOf(6, 7)))
+
+		val result = autoClearNotesUseCase(grid, 0, 0, 1).resultingGrid
+
+		assertEquals(grid, result)
+	}
+
+	@Test
+	fun `Test with a number present in corner notes of cells in the same column`() {
+		// Test if the function correctly removes the number from the corner notes of cells in the same column (excluding the input cell).
+		val grid = SudokuGrid()
+			.withReplacedCell(1, 0, SudokuCellData(1, 0, cornerNotes = persistentSetOf(1, 2)))
+			.withReplacedCell(2, 0, SudokuCellData(2, 0, cornerNotes = persistentSetOf(1, 3)))
+			.withReplacedCell(6, 1, SudokuCellData(6, 1, cornerNotes = persistentSetOf(1, 4)))
+
+		val result = autoClearNotesUseCase(grid, 0, 0, 1).resultingGrid
+
+		assertTrue(result.getCellAt(1, 0).cornerNotes.containsAll(persistentSetOf(2)))
+		assertTrue(result.getCellAt(2, 0).cornerNotes.containsAll(persistentSetOf(3)))
+		assertTrue(
+			result.getCellAt(6, 1).cornerNotes.containsAll(
+				persistentSetOf(1, 4),
+			),
+		) // Unchanged
+	}
+
+	@Test
+	fun `Test with a number present in corner notes of cells in the same row`() {
+		// Test if the function correctly removes the number from the corner notes of cells in the same row (excluding the input cell).
+		val grid = SudokuGrid()
+			.withReplacedCell(0, 1, SudokuCellData(0, 1, cornerNotes = persistentSetOf(1, 2)))
+			.withReplacedCell(0, 2, SudokuCellData(0, 2, cornerNotes = persistentSetOf(1, 3)))
+			.withReplacedCell(6, 6, SudokuCellData(6, 6, cornerNotes = persistentSetOf(1, 4)))
+
+		val result = autoClearNotesUseCase(grid, 0, 0, 1).resultingGrid
+
+		assertTrue(result.getCellAt(0, 1).cornerNotes.containsAll(persistentSetOf(2)))
+		assertTrue(result.getCellAt(0, 2).cornerNotes.containsAll(persistentSetOf(3)))
+		assertTrue(
+			result.getCellAt(6, 6).cornerNotes.containsAll(
+				persistentSetOf(1, 4),
+			),
+		) // Unchanged
+	}
+
+	@Test
+	fun `Test with a number present in corner notes of cells in the same block`() {
+		// Test if the function correctly removes the number from the corner notes of cells in the same block (excluding the input cell and cells with non-zero numbers).
+		val grid = SudokuGrid()
+			.withReplacedCell(1, 1, SudokuCellData(1, 1, cornerNotes = persistentSetOf(1, 2)))
+			.withReplacedCell(2, 2, SudokuCellData(2, 2, cornerNotes = persistentSetOf(1, 3)))
+			.withReplacedCell(
+				3,
+				3,
+				SudokuCellData(3, 3, cornerNotes = persistentSetOf(1, 4)),
+			) // Different block
+
+		val result = autoClearNotesUseCase(grid, 0, 0, 1).resultingGrid
+
+		assertTrue(result.getCellAt(1, 1).cornerNotes.containsAll(persistentSetOf(2)))
+		assertTrue(result.getCellAt(2, 2).cornerNotes.containsAll(persistentSetOf(3)))
+		assertTrue(
+			result.getCellAt(3, 3).cornerNotes.containsAll(
+				persistentSetOf(
+					1,
+					4,
+				),
+			),
+		) // Unchanged
+	}
+
+	@Test
+	fun `Test with a number present in corner notes of cells in the same row  column  and block`() {
+		// Test if the function correctly removes the number from the corner notes of all relevant cells when the number is present in cells belonging to the same row, column, and block.
+		val grid = SudokuGrid()
+			.withReplacedCell(
+				row = 0,
+				col = 1,
+				cellData = SudokuCellData(0, 1, cornerNotes = persistentSetOf(1, 2)),
+			) // Same row
+			.withReplacedCell(
+				row = 1,
+				col = 0,
+				cellData = SudokuCellData(1, 0, cornerNotes = persistentSetOf(1, 3)),
+			) // Same col
+			.withReplacedCell(
+				row = 1,
+				col = 1,
+				cellData = SudokuCellData(1, 1, cornerNotes = persistentSetOf(1, 4)),
+			) // Same block
+			.withReplacedCell(
+				row = 8,
+				col = 8,
+				cellData = SudokuCellData(8, 8, cornerNotes = persistentSetOf(1, 5)),
+			) // Unrelated
+
+		val result = autoClearNotesUseCase(grid, 0, 0, 1).resultingGrid
+
+		assertEquals(persistentSetOf(2), result.getCellAt(0, 1).cornerNotes)
+		assertEquals(persistentSetOf(3), result.getCellAt(1, 0).cornerNotes)
+		assertEquals(persistentSetOf(4), result.getCellAt(1, 1).cornerNotes)
+		assertEquals(persistentSetOf(1, 5), result.getCellAt(8, 8).cornerNotes)
+	}
+
+	@Test
+	fun `Test with an empty SudokuGrid`() {
+		// Test the behavior of the function when an empty SudokuGrid is provided.
+		// This is an edge case to ensure no crashes or unexpected behavior.
+		val grid = SudokuGrid()
+		val result = autoClearNotesUseCase(grid, 0, 0, 1).resultingGrid
+		assertEquals(grid, result)
+	}
+
+	@Test
+	fun `Test with a SudokuGrid where all relevant cells have the number in their corner notes`() {
+		// Test the scenario where all cells in the same row, column, and block (that are eligible for note clearing) have the target number in their corner notes.
+		var grid = SudokuGrid()
+		for (i in 0 until 9) {
+			if (i != 4) {
+				grid = grid.withReplacedCell(
+					row = 4,
+					col = i,
+					cellData = SudokuCellData(4, i, cornerNotes = persistentSetOf(5)),
+				) // row
+			}
+			if (i != 4) {
+				grid = grid.withReplacedCell(
+					row = i,
+					col = 4,
+					cellData = SudokuCellData(i, 4, cornerNotes = persistentSetOf(5)),
+				) // col
+			}
+		}
+		for (r in 3..5) {
+			for (c in 3..5) {
+				if (r != 4 || c != 4) {
+					grid = grid.withReplacedCell(
+						row = r,
+						col = c,
+						cellData = SudokuCellData(r, c, cornerNotes = persistentSetOf(5)),
+					) // block
+				}
+			}
+		}
+
+		val result = autoClearNotesUseCase(grid, 4, 4, 5).resultingGrid
+
+		for (i in 0 until 9) {
+			if (i != 4) assertTrue(result.getCellAt(4, i).cornerNotes.isEmpty())
+			if (i != 4) assertTrue(result.getCellAt(i, 4).cornerNotes.isEmpty())
+		}
+		for (r in 3..5) {
+			for (c in 3..5) {
+				if (r != 4 || c != 4) assertTrue(result.getCellAt(r, c).cornerNotes.isEmpty())
+			}
+		}
+	}
+
+	@Test
+	fun `Test with a SudokuGrid where no cells have the number in their corner notes`() {
+		// Test the scenario where no cells in the SudokuGrid have the target number in their corner notes.
+		val grid = SudokuGrid()
+			.withReplacedCell(0, 1, SudokuCellData(0, 1, cornerNotes = persistentSetOf(2, 3)))
+			.withReplacedCell(1, 0, SudokuCellData(1, 0, cornerNotes = persistentSetOf(2, 3)))
+			.withReplacedCell(1, 1, SudokuCellData(1, 1, cornerNotes = persistentSetOf(2, 3)))
+
+		val result = autoClearNotesUseCase(grid, 0, 0, 1).resultingGrid
+		assertEquals(grid, result)
+	}
+
+	@Test
+	fun `Test with various grid sizes`() {
+		// Test the function with different valid Sudoku grid sizes (e.g., 4x4, 9x9, 16x16) to ensure it works correctly for all supported configurations.
+		// 4x4 grid
+		val grid4 = SudokuGrid(4)
+			.withReplacedCell(0, 1, SudokuCellData(0, 1, cornerNotes = persistentSetOf(1, 2)))
+			.withReplacedCell(1, 0, SudokuCellData(1, 0, cornerNotes = persistentSetOf(1, 3)))
+		val result4 = autoClearNotesUseCase(grid4, 0, 0, 1).resultingGrid
+		assertEquals(persistentSetOf(2), result4.getCellAt(0, 1).cornerNotes)
+		assertEquals(persistentSetOf(3), result4.getCellAt(1, 0).cornerNotes)
+
+		// 16x16 grid
+		val grid16 = SudokuGrid(16)
+			.withReplacedCell(0, 1, SudokuCellData(0, 1, cornerNotes = persistentSetOf(1, 2)))
+			.withReplacedCell(1, 0, SudokuCellData(1, 0, cornerNotes = persistentSetOf(1, 3)))
+		val result16 = autoClearNotesUseCase(grid16, 0, 0, 1).resultingGrid
+		assertEquals(persistentSetOf(2), result16.getCellAt(0, 1).cornerNotes)
+		assertEquals(persistentSetOf(3), result16.getCellAt(1, 0).cornerNotes)
+	}
+
+	@Test
+	fun `Test with row and column at boundary conditions  0 and gridSize 1 `() {
+		// Test the function when the input row and column are at the boundaries of the grid (e.g., first row/column, last row/column).
+		val gridSize = 9
+		// Top-left corner
+		var grid = SudokuGrid(gridSize).withReplacedCell(
+			0,
+			1,
+			SudokuCellData(0, 1, cornerNotes = persistentSetOf(1, 2)),
+		)
+		var result = autoClearNotesUseCase(grid, 0, 0, 1).resultingGrid
+		assertEquals(persistentSetOf(2), result.getCellAt(0, 1).cornerNotes)
+
+		// Bottom-right corner
+		grid = SudokuGrid(gridSize).withReplacedCell(
+			row = gridSize - 1,
+			col = gridSize - 2,
+			cellData = SudokuCellData(
+				gridSize - 1,
+				gridSize - 2,
+				cornerNotes = persistentSetOf(1, 2),
+			),
+		)
+		result = autoClearNotesUseCase(grid, gridSize - 1, gridSize - 1, 1).resultingGrid
+		assertEquals(
+			persistentSetOf(2),
+			result.getCellAt(gridSize - 1, gridSize - 2).cornerNotes,
+		)
+	}
+
+	@Test
+	fun `Test with a number that is the only note in a cell`() {
+		// Test if the function correctly clears the corner notes when the target number is the only note present in a cell's corner notes, resulting in empty corner notes.
+		val grid =
+			SudokuGrid().withReplacedCell(
+				row = 0,
+				col = 1,
+				cellData = SudokuCellData(0, 1, cornerNotes = persistentSetOf(1)),
+			)
+		val result = autoClearNotesUseCase(grid, 0, 0, 1).resultingGrid
+		assertTrue(result.getCellAt(0, 1).cornerNotes.isEmpty())
+	}
+
+	@Test
+	fun `Test with a number that is one of multiple notes in a cell`() {
+		// Test if the function correctly removes only the target number from the corner notes when multiple notes are present in a cell.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 1,
+			cellData = SudokuCellData(0, 1, cornerNotes = persistentSetOf(1, 2, 3)),
+		)
+		val (result) = autoClearNotesUseCase(grid, 0, 0, 1)
+		assertEquals(persistentSetOf(2, 3), result.getCellAt(0, 1).cornerNotes)
+	}
+
+	@Test
+	fun `Test correct handling of cellChanges list`() {
+		// Verify that the cellChanges list is populated correctly with the old and new cell states for each modification made.
+		val grid = SudokuGrid()
+			.withReplacedCell(0, 1, SudokuCellData(0, 1, cornerNotes = persistentSetOf(1, 2)))
+			.withReplacedCell(1, 0, SudokuCellData(1, 0, cornerNotes = persistentSetOf(1, 3)))
+
+		val (result, changes) = autoClearNotesUseCase(grid, 0, 0, 1)
+
+		assertEquals(persistentSetOf(2), result.getCellAt(0, 1).cornerNotes)
+		assertEquals(persistentSetOf(3), result.getCellAt(1, 0).cornerNotes)
+
+		assertEquals(2, changes.size)
+
+		val change1 = changes.find { it.oldCell.row == 1 && it.oldCell.col == 0 }
+		val change2 = changes.find { it.oldCell.row == 0 && it.oldCell.col == 1 }
+
+		assertTrue(change1 != null)
+		assertEquals(persistentSetOf(1, 3), change1!!.oldCell.cornerNotes)
+		assertEquals(persistentSetOf(3), change1.newCell.cornerNotes)
+
+		assertTrue(change2 != null)
+		assertEquals(persistentSetOf(1, 2), change2!!.oldCell.cornerNotes)
+		assertEquals(persistentSetOf(2), change2.newCell.cornerNotes)
+	}
+
+	@Test
+	fun `Test immutability of input SudokuGrid`() {
+		// Ensure that the original SudokuGrid object passed as input is not modified, and a new SudokuGrid object is returned with the changes.
+		val originalGrid =
+			SudokuGrid().withReplacedCell(
+				row = 0,
+				col = 1,
+				cellData = SudokuCellData(0, 1, cornerNotes = persistentSetOf(1, 2)),
+			)
+		val originalGridCopy = originalGrid.copy()
+
+		val result = autoClearNotesUseCase(originalGrid, 0, 0, 1).resultingGrid
+
+		assertNotSame(originalGrid, result)
+		assertEquals(originalGridCopy, originalGrid) // Original grid should be unchanged
+	}
+
+	@Test
+	fun `Test block clearing logic with different subgrid sizes`() {
+		// Specifically test the block clearing logic with varying subgrid sizes (e.g., 2x2 for a 4x4 grid, 3x3 for a 9x9 grid) to ensure the block identification is correct.
+		// 4x4 grid, 2x2 subgrid
+		val grid4 = SudokuGrid(4)
+			.withReplacedCell(
+				row = 1,
+				col = 1,
+				cellData = SudokuCellData(1, 1, cornerNotes = persistentSetOf(1, 2)),
+			) // Same block
+			.withReplacedCell(
+				row = 2,
+				col = 2,
+				cellData = SudokuCellData(2, 2, cornerNotes = persistentSetOf(1, 3)),
+			) // Different block
+		val result4 = autoClearNotesUseCase(grid4, 0, 0, 1).resultingGrid
+		assertEquals(persistentSetOf(2), result4.getCellAt(1, 1).cornerNotes)
+		assertEquals(persistentSetOf(1, 3), result4.getCellAt(2, 2).cornerNotes)
+	}
+
+	@Test
+	fun `Test block clearing exclusion of cells with non zero numbers`() {
+		// Verify that cells within the same block that already have a non-zero number are correctly excluded from note clearing, even if their corner notes contain the target number.
+		val grid = SudokuGrid()
+			.withReplacedCell(
+				row = 1,
+				col = 1,
+				cellData = SudokuCellData(1, 1, 5, cornerNotes = persistentSetOf(1, 2)),
+			)
+
+		val result = autoClearNotesUseCase(grid, 0, 0, 1).resultingGrid
+
+		assertEquals(persistentSetOf(1, 2), result.getCellAt(1, 1).cornerNotes)
+	}
+}

--- a/domain/settings/src/main/java/com/example/domain/settings/SettingsRepository.kt
+++ b/domain/settings/src/main/java/com/example/domain/settings/SettingsRepository.kt
@@ -12,6 +12,7 @@ interface SettingsRepository {
 	val leftHandMode: Flow<Boolean>
 	val showActionButtonsOnTop: Flow<Boolean>
 	val insightsSummaryCompactLayout: Flow<Boolean>
+	val autoClearNotes: Flow<Boolean>
 
 	suspend fun setDarkMode(darkMode: DarkMode)
 
@@ -26,6 +27,8 @@ interface SettingsRepository {
 	suspend fun setShowActionButtonsOnTop(actionButtonsOnTop: Boolean)
 
 	suspend fun setInsightsSummaryCompactLayout(compactLayout: Boolean)
+
+	suspend fun setAutoClearNotes(autoClearNotes: Boolean)
 
 	fun getAvailableColorSchemes(): List<String>
 

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.stateIn
@@ -82,7 +83,7 @@ internal class SudokuGameViewModel(
 					gameState = GameState.LOADING,
 				)
 			}
-			loadData()
+			loadGame()
 			_uiState.update {
 				it.copy(
 					gameState = if (game.value.completed) GameState.VICTORY else GameState.PLAYING,
@@ -97,6 +98,25 @@ internal class SudokuGameViewModel(
 				elapsedTimerManager.startTracking()
 			}
 		}
+
+		viewModelScope.launch {
+			combine(
+				settingsRepository.leftHandMode,
+				settingsRepository.showActionButtonsOnTop,
+				settingsRepository.autoClearNotes,
+			) { leftHandMode, showActionButtonsOnTop, autoClearNotes ->
+				Triple(leftHandMode, showActionButtonsOnTop, autoClearNotes)
+			}.collect { (leftHandMode, showActionButtonsOnTop, autoClearNotes) ->
+				_uiState.update {
+					it.copy(
+						isLeftHandMode = leftHandMode,
+						showActionButtonsOnTop = showActionButtonsOnTop,
+						autoClearNotes = autoClearNotes,
+					)
+				}
+			}
+		}
+
 		viewModelScope.launch {
 			game.collect { game ->
 				gameManagementUseCases.saveGame(
@@ -180,7 +200,7 @@ internal class SudokuGameViewModel(
 		}
 	}
 
-	private suspend fun loadData() {
+	private suspend fun loadGame() {
 		gameManagementUseCases.getGame().first().let { game ->
 			_game.update {
 				it.copy(
@@ -203,22 +223,6 @@ internal class SudokuGameViewModel(
 						currentBestTime = bestTime,
 					)
 				}
-			}
-		}
-
-		settingsRepository.leftHandMode.firstOrNull()?.let { leftHandMode ->
-			_uiState.update {
-				it.copy(isLeftHandMode = leftHandMode)
-			}
-		}
-		settingsRepository.showActionButtonsOnTop.firstOrNull()?.let { actionButtonsOnTop ->
-			_uiState.update {
-				it.copy(showActionButtonsOnTop = actionButtonsOnTop)
-			}
-		}
-		settingsRepository.autoClearNotes.firstOrNull()?.let { autoClearNotes ->
-			_uiState.update {
-				it.copy(autoClearNotes = autoClearNotes)
 			}
 		}
 	}

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -147,20 +147,20 @@ internal class SudokuGameViewModel(
 				inputNumber(
 					number = event.number,
 					selectedCell = _uiState.value.selectedCell,
-					noteMode = _uiState.value.isInNoteMode,
+					isNote = _uiState.value.isInNoteMode,
 				)
 
 			is Event.LongInputNumber -> inputNumber(
 				number = event.number,
 				selectedCell = _uiState.value.selectedCell,
-				noteMode = !uiState.value.isInNoteMode,
+				isNote = !uiState.value.isInNoteMode,
 			)
 
 			is Event.ClearCell ->
 				inputNumber(
 					number = 0,
 					selectedCell = _uiState.value.selectedCell,
-					noteMode = _uiState.value.isInNoteMode,
+					isNote = _uiState.value.isInNoteMode,
 				)
 
 			is Event.Undo -> undoLastMove()
@@ -216,6 +216,11 @@ internal class SudokuGameViewModel(
 				it.copy(showActionButtonsOnTop = actionButtonsOnTop)
 			}
 		}
+		settingsRepository.autoClearNotes.firstOrNull()?.let { autoClearNotes ->
+			_uiState.update {
+				it.copy(autoClearNotes = autoClearNotes)
+			}
+		}
 	}
 
 	private fun selectCell(row: Int, col: Int) {
@@ -241,12 +246,13 @@ internal class SudokuGameViewModel(
 	private fun inputNumber(
 		number: Int,
 		selectedCell: Pair<Int, Int>?,
-		noteMode: Boolean,
+		isNote: Boolean,
 		isHint: Boolean = false,
 	) {
 		viewModelScope.launch {
 			if (uiState.value.gameState == GameState.VICTORY) return@launch
 			var updatedSudoku = _game.value.grid
+			val changes = mutableListOf<CellChange>()
 			val (row, col) = selectedCell ?: return@launch
 
 			val backupCell = updatedSudoku.getCellAt(row, col)
@@ -256,19 +262,30 @@ internal class SudokuGameViewModel(
 					number = number,
 					row = row,
 					column = col,
-					isNote = noteMode,
+					isNote = isNote,
 					isHint = isHint,
 				)
+			changes.add(
+				CellChange(
+					oldCell = backupCell,
+					newCell = updatedSudoku.getCellAt(row, col),
+				),
+			)
+			if (uiState.value.autoClearNotes && !isNote) {
+				val (newSudoku, noteChanges) = gameManagementUseCases.autoClearNotes(
+					sudokuGrid = updatedSudoku,
+					row = row,
+					column = col,
+					number = number,
+				)
+				updatedSudoku = newSudoku
+				changes.addAll(noteChanges)
+			}
 			operationRepository.apply {
 				addUndoOperation(
 					Operation(
 						id = operationRepository.getUndoOperations().size.toLong(),
-						changes = listOf(
-							CellChange(
-								oldCell = backupCell,
-								newCell = updatedSudoku.getCellAt(row, col),
-							),
-						),
+						changes = changes,
 					),
 				)
 				clearRedoOperations()

--- a/feature/game/src/main/java/com/example/feature/game/model/GameModels.kt
+++ b/feature/game/src/main/java/com/example/feature/game/model/GameModels.kt
@@ -11,6 +11,7 @@ internal data class SudokuGameUiState(
 	val showActionButtonsOnTop: Boolean = false,
 	val currentBestTime: Long? = null,
 	val isNewBestTime: Boolean = false,
+	val autoClearNotes: Boolean = true,
 )
 
 internal enum class GameState {

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsScreen.kt
@@ -44,6 +44,7 @@ internal fun SettingsScreen(
 	val actionButtonsOnTop by viewModel.actionButtonsOnTop.collectAsStateWithLifecycle()
 	val insightsSummaryCompactLayout by
 		viewModel.insightsSummaryCompactLayout.collectAsStateWithLifecycle()
+	val autoClearNotes by viewModel.autoClearNotes.collectAsStateWithLifecycle()
 
 	SettingsScreenContent(
 		openDrawer = openDrawer,
@@ -56,6 +57,7 @@ internal fun SettingsScreen(
 		leftHandMode = leftHandMode,
 		actionButtonsOnTop = actionButtonsOnTop,
 		insightsSummaryCompactLayout = insightsSummaryCompactLayout,
+		autoClearNotes = autoClearNotes,
 		modifier = modifier.fillMaxSize(),
 	)
 }
@@ -72,6 +74,7 @@ private fun SettingsScreenContent(
 	leftHandMode: Boolean,
 	actionButtonsOnTop: Boolean,
 	insightsSummaryCompactLayout: Boolean,
+	autoClearNotes: Boolean,
 	darkMode: String,
 	modifier: Modifier = Modifier,
 ) {
@@ -167,6 +170,16 @@ private fun SettingsScreenContent(
 					modifier = Modifier.fillMaxWidth(),
 				)
 			}
+
+			SettingsCategory("Gameplay") {
+				SettingSwitchItem(
+					title = "Auto clear notes",
+					value = autoClearNotes,
+					description = "Clear notes when a number is input",
+					onValueChange = { onEvent(SettingsViewModel.Event.ToggleAutoClearNotes(it)) },
+					modifier = Modifier.fillMaxWidth(),
+				)
+			}
 		}
 	}
 }
@@ -186,6 +199,7 @@ private fun SettingsScreenPreview() {
 			darkMode = "System",
 			actionButtonsOnTop = false,
 			insightsSummaryCompactLayout = false,
+			autoClearNotes = true,
 			modifier = Modifier.fillMaxSize(),
 		)
 	}

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
@@ -58,6 +58,9 @@ class SettingsViewModel(
 			initialValue = true,
 		)
 
+	val autoClearNotes: StateFlow<Boolean> =
+		settingsRepository.autoClearNotes.stateInViewModel(initialValue = true)
+
 	val lightColorSchemes = settingsRepository.getLightColorSchemes().toPersistentSet()
 	val darkColorSchemes = settingsRepository.getDarkColorSchemes().toPersistentSet()
 
@@ -75,6 +78,8 @@ class SettingsViewModel(
 		data class ToggleActionButtonsOnTop(val actionButtonsOnTop: Boolean) : Event
 
 		data class ToggleInsightsSummaryCompactLayout(val compactLayout: Boolean) : Event
+
+		data class ToggleAutoClearNotes(val autoClearNotes: Boolean) : Event
 	}
 
 	fun onEvent(event: Event) {
@@ -88,6 +93,8 @@ class SettingsViewModel(
 			is Event.ToggleInsightsSummaryCompactLayout -> toggleInsightsSummaryCompactLayout(
 				event.compactLayout,
 			)
+
+			is Event.ToggleAutoClearNotes -> toggleAutoClearNotes(event.autoClearNotes)
 		}
 	}
 
@@ -130,6 +137,12 @@ class SettingsViewModel(
 	private fun toggleActionButtonsOnTop(actionButtonsOnTop: Boolean) {
 		viewModelScope.launch {
 			settingsRepository.setShowActionButtonsOnTop(actionButtonsOnTop)
+		}
+	}
+
+	private fun toggleAutoClearNotes(autoClearNotes: Boolean) {
+		viewModelScope.launch {
+			settingsRepository.setAutoClearNotes(autoClearNotes)
 		}
 	}
 }


### PR DESCRIPTION
This pull request introduces a new feature, "Auto Clear Notes," which automatically removes corner notes from Sudoku cells based on certain conditions. The changes span multiple files and include updates to the repository, domain logic, and unit tests. Key updates include adding support for the "Auto Clear Notes" feature in the settings repository, implementing the core logic for clearing notes, and testing the functionality thoroughly.

### Feature Implementation: Auto Clear Notes

#### Repository Updates
* Added `autoClearNotes` property and corresponding setter method to `AndroidSettingsRepository` for managing the "Auto Clear Notes" setting. (`AndroidSettingsRepository.kt`, [[1]](diffhunk://#diff-c9523922259fc2d4e847df28b37bf1582833548cc0ae8bba5a48d879da67685bR47-R50) [[2]](diffhunk://#diff-c9523922259fc2d4e847df28b37bf1582833548cc0ae8bba5a48d879da67685bR79-R82)
* Introduced a new preference key, `AutoClearNotes`, in `SettingsPreferenceKeys` to store the default value and name for the setting. (`SettingsPreferenceKeys.kt`, [data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.ktR36-R40](diffhunk://#diff-ce8d272fd3a3413aa4c6d4c19a591004cfa9cca3305033c189b6d3018c9cf430R36-R40))

#### Domain Logic
* Added `AutoClearNotesUseCase` to handle the logic for clearing corner notes in Sudoku cells based on row, column, and block constraints. (`AutoClearNotesUseCase.kt`, [domain/game/src/main/java/com/example/domain/game/usecases/AutoClearNotesUseCase.ktR1-R63](diffhunk://#diff-a353decf4c23cc587853724b9c42b3f1203d1ad45ba347889cd88580fd6fa5d4R1-R63))
* Introduced `GameUpdate` data class to encapsulate the result of game state modifications, including the updated grid and a list of changes. (`GameUpdate.kt`, [domain/game/src/main/java/com/example/domain/game/GameUpdate.ktR1-R12](diffhunk://#diff-f05b3d580dfe5e6add51c90572bcd18a019f7d1fe385708a08baf20fa7eb09e2R1-R12))

#### Dependency Injection
* Registered `AutoClearNotesUseCase` in the domain game module for dependency injection. (`Module.kt`, [[1]](diffhunk://#diff-f97d44336ce3b1437b67b2083ec01f7f3e7de6bc261111998399739097995ac6R46) [[2]](diffhunk://#diff-f97d44336ce3b1437b67b2083ec01f7f3e7de6bc261111998399739097995ac6R75)

### Unit Testing
* Created comprehensive unit tests for `AutoClearNotesUseCase` to validate its behavior under various scenarios, including edge cases and different grid sizes. (`AutoClearNotesUseCaseTest.kt`, [domain/game/src/test/java/com/example/domain/game/usecases/AutoClearNotesUseCaseTest.ktR1-R350](diffhunk://#diff-d3d46e249010a1e1bae34d29ef0e1a81a3ea836ae28f7a299dc758f90b57a3bcR1-R350))

### Interface Updates
* Updated `SettingsRepository` to include `autoClearNotes` property and setter method, ensuring the feature is accessible at the domain level. (`SettingsRepository.kt`, [[1]](diffhunk://#diff-15e7703f8a985933c09f17129d6df65b8431d17d53c41c297e494daa0b476e2bR15) [[2]](diffhunk://#diff-15e7703f8a985933c09f17129d6df65b8431d17d53c41c297e494daa0b476e2bR31-R32)