### PR TITLE
Refactor: improve timer logic and lifecycle management

### DIFF
--- a/domain/game/src/main/java/com/example/domain/game/ElapsedTimerManager.kt
+++ b/domain/game/src/main/java/com/example/domain/game/ElapsedTimerManager.kt
@@ -2,31 +2,32 @@ package com.example.domain.game
 
 import com.example.domain.game.usecases.GetElapsedTimeUseCase
 import com.example.domain.game.usecases.SaveElapsedTimeUseCase
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class ElapsedTimerManager(
+	private val scope: CoroutineScope,
 	private val getElapsedTimeUseCase: GetElapsedTimeUseCase,
 	private val saveElapsedTimeUseCase: SaveElapsedTimeUseCase,
 ) {
-	private var isRunning = false
-	private var _elapsedTime = MutableStateFlow<Long>(0L)
+	private val isRunning = AtomicBoolean(false)
+	private val _elapsedTime = MutableStateFlow<Long>(0L)
 	private var timerJob: Job? = null
 	private var saveJob: Job? = null
-	val elapsedTime: StateFlow<Long>
-		get() {
-			return _elapsedTime
-		}
+	val elapsedTime: StateFlow<Long> = _elapsedTime.asStateFlow()
 
 	init {
-		CoroutineScope(Dispatchers.Default).launch {
+		scope.launch {
 			_elapsedTime.update {
 				getElapsedTimeUseCase().firstOrNull() ?: 0L
 			}
@@ -34,21 +35,25 @@ class ElapsedTimerManager(
 	}
 
 	fun startTracking() {
-		if (isRunning) return
+		if (isRunning.getAndSet(true)) return
+		scope.launch {
+			_elapsedTime.update {
+				getElapsedTimeUseCase().firstOrNull() ?: 0L
+			}
+		}
 
-		isRunning = true
 		timerJob =
-			CoroutineScope(Dispatchers.Default).launch {
-				while (isRunning) {
+			scope.launch(Dispatchers.Default) {
+				while (isRunning.get()) {
 					delay(1000)
 					_elapsedTime.update { it + 1 }
 				}
 			}
 		saveJob =
-			CoroutineScope(Dispatchers.Default).launch {
-				while (isRunning) {
+			scope.launch(Dispatchers.Default) {
+				while (isRunning.get()) {
 					delay(10000L)
-					if (isRunning) {
+					if (isRunning.get()) {
 						saveElapsedTimeUseCase(elapsedTime.value)
 					}
 				}
@@ -56,15 +61,15 @@ class ElapsedTimerManager(
 	}
 
 	suspend fun stopTracking() {
-		if (isRunning) {
-			isRunning = false
-			timerJob?.cancel()
-			saveJob?.cancel()
+		if (isRunning.getAndSet(false)) {
+			timerJob?.cancelAndJoin()
+			saveJob?.cancelAndJoin()
 			saveElapsedTimeUseCase(elapsedTime.value)
 		}
 	}
 
 	suspend fun resetTimer() {
+		stopTracking()
 		_elapsedTime.update {
 			0L
 		}

--- a/feature/game/src/main/java/com/example/feature/game/Module.kt
+++ b/feature/game/src/main/java/com/example/feature/game/Module.kt
@@ -1,6 +1,5 @@
 package com.example.feature.game
 
-import com.example.domain.game.ElapsedTimerManager
 import com.example.domain.game.domainGameModule
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
@@ -17,9 +16,9 @@ val gameModule =
 				undoOperationUseCase = get(),
 				redoOperationUseCase = get(),
 				getBestTimeUseCase = get(),
-				elapsedTimerManager = get(),
+				getElapsedTimeUseCase = get(),
+				saveElapsedTimeUseCase = get(),
 				gameResultWriter = get(),
 			)
 		}
-		factory { ElapsedTimerManager(get(), get()) }
 	}

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
@@ -35,11 +35,11 @@ import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Devices.AUTOMOTIVE_1024p
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.composables.core.rememberDialogState
 import com.example.domain.core.Game
@@ -76,6 +76,14 @@ internal fun SudokuGameScreen(
 	val elapsedTime by viewModel.elapsedTime.collectAsStateWithLifecycle()
 	val uiState: SudokuGameUiState by viewModel.uiState.collectAsStateWithLifecycle()
 	val game by viewModel.game.collectAsStateWithLifecycle()
+
+	LifecycleResumeEffect(Unit) {
+		viewModel.onEvent(Event.StartTimer)
+		onPauseOrDispose {
+			viewModel.onEvent(Event.StopTimer)
+		}
+	}
+
 	SudokuGameScreenContent(
 		uiState = uiState,
 		game = game,
@@ -187,8 +195,7 @@ private fun SudokuGameScreenContent(
 				windowInsets = WindowInsets.displayCutout,
 				title = {
 					TimerDisplay(
-						elapsedTime = { elapsedTime() },
-						onPause = { onEvent(Event.StopTimer) },
+						elapsedTime = elapsedTime(),
 					)
 				},
 				colors =
@@ -297,7 +304,7 @@ private fun SudokuGameScreenContent(
 						contentAlignment = Alignment.Center,
 					) { state ->
 						when (state) {
-							GameState.LOADING -> { }
+							GameState.LOADING -> {}
 							GameState.PLAYING -> {
 								KeyPad(
 									onNumberClick = { onEvent(Event.InputNumber(it)) },
@@ -388,7 +395,7 @@ private fun SudokuGameScreenSixteenPreview() {
 }
 
 @Preview(
-	device = Devices.AUTOMOTIVE_1024p,
+	device = AUTOMOTIVE_1024p,
 )
 @Composable
 private fun SudokuGameScreenFourPreview() {

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -14,7 +14,9 @@ import com.example.domain.game.GameManagementUseCases
 import com.example.domain.game.HintUseCases
 import com.example.domain.game.repositories.GameResultWriter
 import com.example.domain.game.usecases.GetBestTimeUseCase
+import com.example.domain.game.usecases.GetElapsedTimeUseCase
 import com.example.domain.game.usecases.RedoOperationUseCase
+import com.example.domain.game.usecases.SaveElapsedTimeUseCase
 import com.example.domain.game.usecases.UndoOperationUseCase
 import com.example.domain.settings.SettingsRepository
 import com.example.feature.game.model.GameState
@@ -51,10 +53,17 @@ internal class SudokuGameViewModel(
 	private val undoOperationUseCase: UndoOperationUseCase,
 	private val redoOperationUseCase: RedoOperationUseCase,
 	private val getBestTimeUseCase: GetBestTimeUseCase,
-	private val elapsedTimerManager: ElapsedTimerManager,
 	private val gameResultWriter: GameResultWriter,
+	private val getElapsedTimeUseCase: GetElapsedTimeUseCase,
+	private val saveElapsedTimeUseCase: SaveElapsedTimeUseCase,
 ) : ViewModel() {
+	private val elapsedTimerManager = ElapsedTimerManager(
+		scope = viewModelScope,
+		getElapsedTimeUseCase = getElapsedTimeUseCase,
+		saveElapsedTimeUseCase = saveElapsedTimeUseCase,
+	)
 	private val mutex = Mutex()
+
 	private val _uiState = MutableStateFlow<SudokuGameUiState>(SudokuGameUiState())
 	val uiState: StateFlow<SudokuGameUiState> = _uiState
 
@@ -158,6 +167,8 @@ internal class SudokuGameViewModel(
 		data object ResetNotes : Event
 
 		data object StopTimer : Event
+
+		data object StartTimer : Event
 	}
 
 	fun onEvent(event: Event) {
@@ -196,6 +207,9 @@ internal class SudokuGameViewModel(
 			is Event.ResetNotes -> resetNotes()
 			is Event.StopTimer -> {
 				stopTrackingTime()
+			}
+			is Event.StartTimer -> {
+				elapsedTimerManager.startTracking()
 			}
 		}
 	}

--- a/feature/game/src/main/java/com/example/feature/game/components/Timer.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/Timer.kt
@@ -6,22 +6,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
-internal fun TimerDisplay(
-	elapsedTime: () -> Long,
-	onPause: () -> Unit,
-	modifier: Modifier = Modifier,
-) {
-	LifecycleResumeEffect(Unit) {
-		onPauseOrDispose {
-			onPause()
-		}
-	}
-
-	val string = elapsedTime().seconds.toString()
+internal fun TimerDisplay(elapsedTime: Long, modifier: Modifier = Modifier) {
+	val string = elapsedTime.seconds.toString()
 	Box(modifier = modifier) {
 		Text(
 			text = string,
@@ -35,8 +24,7 @@ internal fun TimerDisplay(
 @Composable
 private fun TimerPreview() {
 	TimerDisplay(
-		elapsedTime = { 61L },
-		onPause = { },
+		elapsedTime = 61L,
 		modifier = Modifier,
 	)
 }


### PR DESCRIPTION
This commit refactors the timer functionality in the game screen for better lifecycle handling and state management.

**Key Changes:**

-   **`ElapsedTimerManager.kt`:**
    -   Now takes a `CoroutineScope` in its constructor, typically `viewModelScope`, to manage its coroutines.
    -   Uses `AtomicBoolean` for `isRunning` to ensure thread-safe updates.
    -   Timer and save jobs are launched within the provided `scope`.
    -   `startTracking()` now re-fetches the elapsed time from `getElapsedTimeUseCase` before starting the timer.
    -   `stopTracking()` now uses `cancelAndJoin()` to ensure jobs are fully stopped before proceeding.
    -   `resetTimer()` now explicitly calls `stopTracking()` before resetting the time to 0.
-   **`SudokuGameViewModel.kt`:**
    -   The `ElapsedTimerManager` is now instantiated directly within the ViewModel, passing `viewModelScope`.
    -   Added a new `Event.StartTimer` to explicitly start the timer.
    -   `onEvent(Event.StartTimer)` now calls `elapsedTimerManager.startTracking()`.
-   **`SudokuGameScreen.kt`:**
    -   A `LifecycleResumeEffect` is used to manage the timer's lifecycle:
        -   `Event.StartTimer` is dispatched when the screen resumes.
        -   `Event.StopTimer` is dispatched when the screen pauses or is disposed.
-   **`TimerDisplay.kt` (Component):**
    -   Removed the `onPause` lambda and the internal `LifecycleResumeEffect` as timer lifecycle is now managed by the ViewModel and `SudokuGameScreen`.
    -   The `elapsedTime` parameter is now a direct `Long` value instead of a lambda.
-   **`feature/game/Module.kt`:**
    -   Removed the Koin factory provider for `ElapsedTimerManager` as it's now created within `SudokuGameViewModel`.
    -   `SudokuGameViewModel` constructor now directly takes `getElapsedTimeUseCase` and `saveElapsedTimeUseCase` instead of the manager.