### PR TITLE
Feat: add generated number color in SudokuCell

### DIFF
--- a/feature/game/src/main/java/com/example/feature/game/components/SudokuCell.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/SudokuCell.kt
@@ -172,6 +172,10 @@ internal fun SudokuCell(
 							CellAttributes.HINT_REVEALED,
 						) -> LocalSudokuBoardColors.current.onHintMarkBackground
 
+						data.attributes.contains(
+							CellAttributes.GENERATED
+						) -> LocalSudokuBoardColors.current.generatedNumber
+
 						else -> LocalSudokuBoardColors.current.onDefaultBackground
 					}
 				Box(

--- a/feature/game/src/main/java/com/example/feature/game/theme/SudokuBoardColors.kt
+++ b/feature/game/src/main/java/com/example/feature/game/theme/SudokuBoardColors.kt
@@ -11,6 +11,7 @@ import com.example.feature.uicore.theme.CatppuccinPalette
 internal data class SudokuBoardColors(
 	val defaultBackground: Color,
 	val onDefaultBackground: Color,
+	val generatedNumber: Color,
 	val selectedBackground: Color,
 	val onSelectedBackground: Color,
 	val highlightedBackground: Color,
@@ -46,6 +47,7 @@ internal object BoardColorSchemes {
 		onMatchingMarkBackground = palette.crust,
 		cellBorder = palette.overlay0,
 		blockBorder = palette.overlay2,
+		generatedNumber = palette.subtext0,
 	)
 }
 


### PR DESCRIPTION
This commit updates the `SudokuCell` composable to display generated numbers in a distinct color.

**Key Changes:**

-   **`SudokuBoardColors.kt`:**
    -   Added a `generatedNumber` color property to the `SudokuBoardColors` data class.
-   **`SudokuCell.kt`:**
    -   The color of the main number text in a cell is now set to `LocalSudokuBoardColors.current.generatedNumber` if the cell's attributes contain `CellAttributes.GENERATED`. Otherwise, it defaults to `LocalSudokuBoardColors.current.onDefaultBackground`.