### PR TITLE
Fix/consistent matching number highlighting

### DIFF
--- a/domain/game/src/main/java/com/example/domain/game/GameManagementUseCases.kt
+++ b/domain/game/src/main/java/com/example/domain/game/GameManagementUseCases.kt
@@ -5,6 +5,7 @@ import com.example.domain.game.usecases.ClearActiveGameUseCase
 import com.example.domain.game.usecases.FocusOnHintCellsUseCase
 import com.example.domain.game.usecases.GenerateHintLogUseCase
 import com.example.domain.game.usecases.GetGameUseCase
+import com.example.domain.game.usecases.HighlightMatchingNumbersUseCase
 import com.example.domain.game.usecases.InputNumberUseCase
 import com.example.domain.game.usecases.ProvideHintUseCase
 import com.example.domain.game.usecases.ResetGameUseCase
@@ -21,6 +22,7 @@ data class GameManagementUseCases(
 	val resetGame: ResetGameUseCase,
 	val clearActiveGame: ClearActiveGameUseCase,
 	val autoClearNotes: AutoClearNotesUseCase,
+	val highlightMatching: HighlightMatchingNumbersUseCase,
 )
 
 data class HintUseCases(

--- a/domain/game/src/main/java/com/example/domain/game/Module.kt
+++ b/domain/game/src/main/java/com/example/domain/game/Module.kt
@@ -34,7 +34,13 @@ val domainGameModule =
 		factory { ClearActiveGameUseCase(get()) }
 		factory { GetBestTimeUseCase(get()) }
 
-		factory { SelectCellUseCase(get(), get(), get()) }
+		factory {
+			SelectCellUseCase(
+				highlightRowAndColumnUseCase = get(),
+				highlightMatchingNumbersUseCase = get(),
+				clearHighlightedRowAndColumnUseCase = get(),
+			)
+		}
 		factory { HighlightMatchingNumbersUseCase() }
 		factory { HighlightRowAndColumnUseCase() }
 		factory { ClearHighlightedRowAndColumnUseCase() }
@@ -49,8 +55,20 @@ val domainGameModule =
 		factory { RevealHintOnGridUseCase(get()) }
 		factory { RevealLastHintLogUseCase() }
 
-		factory { UndoOperationUseCase(get(), get()) }
-		factory { RedoOperationUseCase(get(), get()) }
+		factory {
+			UndoOperationUseCase(
+				operationRepository = get(),
+				inputNumberUseCase = get(),
+				highlightMatchingNumbersUseCase = get(),
+			)
+		}
+		factory {
+			RedoOperationUseCase(
+				operationRepository = get(),
+				inputNumberUseCase = get(),
+				highlightMatchingNumbersUseCase = get(),
+			)
+		}
 
 		factory {
 			HintUseCases(

--- a/domain/game/src/main/java/com/example/domain/game/Module.kt
+++ b/domain/game/src/main/java/com/example/domain/game/Module.kt
@@ -2,7 +2,6 @@ package com.example.domain.game
 
 import com.example.domain.game.usecases.AutoClearNotesUseCase
 import com.example.domain.game.usecases.ClearActiveGameUseCase
-import com.example.domain.game.usecases.ClearHighlightedNumbersUseCase
 import com.example.domain.game.usecases.ClearHighlightedRowAndColumnUseCase
 import com.example.domain.game.usecases.FocusOnHintCellsUseCase
 import com.example.domain.game.usecases.GenerateHintLogUseCase
@@ -35,9 +34,8 @@ val domainGameModule =
 		factory { ClearActiveGameUseCase(get()) }
 		factory { GetBestTimeUseCase(get()) }
 
-		factory { SelectCellUseCase(get(), get(), get(), get()) }
+		factory { SelectCellUseCase(get(), get(), get()) }
 		factory { HighlightMatchingNumbersUseCase() }
-		factory { ClearHighlightedNumbersUseCase(get()) }
 		factory { HighlightRowAndColumnUseCase() }
 		factory { ClearHighlightedRowAndColumnUseCase() }
 

--- a/domain/game/src/main/java/com/example/domain/game/Module.kt
+++ b/domain/game/src/main/java/com/example/domain/game/Module.kt
@@ -73,6 +73,7 @@ val domainGameModule =
 				resetGame = get(),
 				clearActiveGame = get(),
 				autoClearNotes = get(),
+				highlightMatching = get(),
 			)
 		}
 	}

--- a/domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.kt
@@ -1,37 +1,16 @@
 package com.example.domain.game.usecases
 
-import com.example.sudoku.model.CellAttributes
 import com.example.sudoku.model.SudokuGrid
-import com.example.sudoku.model.addAttribute
-import com.example.sudoku.model.removeAttribute
+import com.example.sudoku.model.clearMatchingNumberHighlight
+import com.example.sudoku.model.highlightMatchingCells
 
 class HighlightMatchingNumbersUseCase {
 	operator fun invoke(sudokuGrid: SudokuGrid, number: Int?): SudokuGrid {
-		var updatedSudoku =
-			sudokuGrid.removeAttribute(
-				predicate = { cell -> cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED) },
-				attribute = CellAttributes.NUMBER_MATCH_HIGHLIGHTED,
-			)
-
-		updatedSudoku = number?.let {
-			updatedSudoku.addAttribute(
-				predicate = { cell -> number != 0 && cell.number == number },
-				attribute = CellAttributes.NUMBER_MATCH_HIGHLIGHTED,
-			)
-		} ?: updatedSudoku.removeAttribute(
-			predicate = { cell -> cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED) },
-			attribute = CellAttributes.NUMBER_MATCH_HIGHLIGHTED,
-		)
-
-		return updatedSudoku
+		val clearedGrid = sudokuGrid.clearMatchingNumberHighlight()
+		return if (number != null) {
+			clearedGrid.highlightMatchingCells(number)
+		} else {
+			clearedGrid
+		}
 	}
-}
-
-class ClearHighlightedNumbersUseCase(
-	private val highlightMatchingNumbersUseCase: HighlightMatchingNumbersUseCase,
-) {
-	operator fun invoke(sudoku: SudokuGrid): SudokuGrid = highlightMatchingNumbersUseCase(
-		sudokuGrid = sudoku,
-		number = null,
-	)
 }

--- a/domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.kt
@@ -6,9 +6,9 @@ import com.example.sudoku.model.addAttribute
 import com.example.sudoku.model.removeAttribute
 
 class HighlightMatchingNumbersUseCase {
-	operator fun invoke(sudoku: SudokuGrid, number: Int?): SudokuGrid {
+	operator fun invoke(sudokuGrid: SudokuGrid, number: Int?): SudokuGrid {
 		var updatedSudoku =
-			sudoku.removeAttribute(
+			sudokuGrid.removeAttribute(
 				predicate = { cell -> cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED) },
 				attribute = CellAttributes.NUMBER_MATCH_HIGHLIGHTED,
 			)
@@ -31,7 +31,7 @@ class ClearHighlightedNumbersUseCase(
 	private val highlightMatchingNumbersUseCase: HighlightMatchingNumbersUseCase,
 ) {
 	operator fun invoke(sudoku: SudokuGrid): SudokuGrid = highlightMatchingNumbersUseCase(
-		sudoku = sudoku,
+		sudokuGrid = sudoku,
 		number = null,
 	)
 }

--- a/domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.kt
@@ -7,7 +7,7 @@ import com.example.sudoku.model.highlightMatchingCells
 class HighlightMatchingNumbersUseCase {
 	operator fun invoke(sudokuGrid: SudokuGrid, number: Int?): SudokuGrid {
 		val clearedGrid = sudokuGrid.clearMatchingNumberHighlight()
-		return if (number != null) {
+		return if (number != null && number != 0) {
 			clearedGrid.highlightMatchingCells(number)
 		} else {
 			clearedGrid

--- a/domain/game/src/main/java/com/example/domain/game/usecases/HighlightRowAndColumnUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/HighlightRowAndColumnUseCase.kt
@@ -1,20 +1,14 @@
 package com.example.domain.game.usecases
 
-import com.example.sudoku.model.CellAttributes
 import com.example.sudoku.model.SudokuGrid
-import com.example.sudoku.model.addAttribute
-import com.example.sudoku.model.removeAttribute
+import com.example.sudoku.model.clearRowColumnHighlight
+import com.example.sudoku.model.highlightRowAndColumn
 
 class HighlightRowAndColumnUseCase {
-	operator fun invoke(sudoku: SudokuGrid, row: Int, column: Int): SudokuGrid = sudoku.addAttribute(
-		predicate = { cell -> cell.row == row || cell.col == column },
-		attribute = CellAttributes.ROW_COLUMN_HIGHLIGHTED,
-	)
+	operator fun invoke(sudoku: SudokuGrid, row: Int, column: Int): SudokuGrid =
+		sudoku.highlightRowAndColumn(row, column)
 }
 
 class ClearHighlightedRowAndColumnUseCase {
-	operator fun invoke(sudoku: SudokuGrid): SudokuGrid = sudoku.removeAttribute(
-		predicate = { cell -> cell.attributes.contains(CellAttributes.ROW_COLUMN_HIGHLIGHTED) },
-		attribute = CellAttributes.ROW_COLUMN_HIGHLIGHTED,
-	)
+	operator fun invoke(sudoku: SudokuGrid): SudokuGrid = sudoku.clearRowColumnHighlight()
 }

--- a/domain/game/src/main/java/com/example/domain/game/usecases/InputNumberUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/InputNumberUseCase.kt
@@ -51,7 +51,12 @@ class InputNumberUseCase {
 					cell.copy(
 						number = if (number == cell.number) 0 else number,
 						cornerNotes = persistentSetOf(),
-						attributes = if (isHint) cell.attributes + CellAttributes.HINT_REVEALED else cell.attributes,
+						attributes = if (isHint) {
+							cell.attributes + CellAttributes.HINT_REVEALED
+						} else {
+							cell.attributes -
+								CellAttributes.HINT_REVEALED
+						},
 					)
 			}
 

--- a/domain/game/src/main/java/com/example/domain/game/usecases/RedoOperationUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/RedoOperationUseCase.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class RedoOperationUseCase(
 	private val operationRepository: OperationRepository,
 	private val inputNumberUseCase: InputNumberUseCase,
+	private val highlightMatchingNumbersUseCase: HighlightMatchingNumbersUseCase,
 ) {
 	private val mutex = Mutex()
 	private val isProcessing = AtomicBoolean(false)
@@ -66,6 +67,7 @@ class RedoOperationUseCase(
 							isNote = false,
 							isHint = newCell.attributes.contains(CellAttributes.HINT_REVEALED),
 						)
+						updatedGrid = highlightMatchingNumbersUseCase(updatedGrid, newCell.number)
 					}
 				}
 				return updatedGrid

--- a/domain/game/src/main/java/com/example/domain/game/usecases/SelectCellUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/SelectCellUseCase.kt
@@ -18,10 +18,15 @@ class SelectCellUseCase(
 				attribute = CellAttributes.SELECTED,
 			)
 
-		updatedSudoku =
-			clearHighlightedNumbersUseCase(
-				sudoku = updatedSudoku,
-			)
+		if (selectedCell == null) {
+			updatedSudoku = clearHighlightedNumbersUseCase(updatedSudoku)
+		} else {
+			selectedCell.let { (row, col) ->
+				if (updatedSudoku.getCellAt(row, col).number != 0) {
+					updatedSudoku = clearHighlightedNumbersUseCase(updatedSudoku)
+				}
+			}
+		}
 		updatedSudoku =
 			clearHighlightedRowAndColumnUseCase(
 				sudoku = updatedSudoku,
@@ -44,11 +49,13 @@ class SelectCellUseCase(
 					row = row,
 					column = col,
 				)
-			updatedSudoku =
-				highlightMatchingNumbersUseCase(
-					sudoku = updatedSudoku,
-					number = cell.number.takeIf { it != 0 },
-				)
+			if (cell.number != 0) {
+				updatedSudoku =
+					highlightMatchingNumbersUseCase(
+						sudoku = updatedSudoku,
+						number = cell.number,
+					)
+			}
 		}
 
 		return updatedSudoku

--- a/domain/game/src/main/java/com/example/domain/game/usecases/SelectCellUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/SelectCellUseCase.kt
@@ -8,7 +8,6 @@ import kotlinx.collections.immutable.plus
 class SelectCellUseCase(
 	private val highlightRowAndColumnUseCase: HighlightRowAndColumnUseCase,
 	private val highlightMatchingNumbersUseCase: HighlightMatchingNumbersUseCase,
-	private val clearHighlightedNumbersUseCase: ClearHighlightedNumbersUseCase,
 	private val clearHighlightedRowAndColumnUseCase: ClearHighlightedRowAndColumnUseCase,
 ) {
 	operator fun invoke(sudoku: SudokuGrid, selectedCell: Pair<Int, Int>? = null): SudokuGrid {
@@ -19,11 +18,11 @@ class SelectCellUseCase(
 			)
 
 		if (selectedCell == null) {
-			updatedSudoku = clearHighlightedNumbersUseCase(updatedSudoku)
+			updatedSudoku = highlightMatchingNumbersUseCase(updatedSudoku, null)
 		} else {
 			selectedCell.let { (row, col) ->
 				if (updatedSudoku.getCellAt(row, col).number != 0) {
-					updatedSudoku = clearHighlightedNumbersUseCase(updatedSudoku)
+					updatedSudoku = highlightMatchingNumbersUseCase(updatedSudoku, null)
 				}
 			}
 		}

--- a/domain/game/src/main/java/com/example/domain/game/usecases/SelectCellUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/SelectCellUseCase.kt
@@ -27,8 +27,7 @@ class SelectCellUseCase(
 				sudoku = updatedSudoku,
 			)
 
-		selectedCell?.let {
-			val (row, col) = it
+		selectedCell?.let { (row, col) ->
 			val cell = updatedSudoku.getCellAt(row, col)
 			updatedSudoku =
 				updatedSudoku.withReplacedCell(
@@ -48,7 +47,7 @@ class SelectCellUseCase(
 			updatedSudoku =
 				highlightMatchingNumbersUseCase(
 					sudoku = updatedSudoku,
-					number = cell.number,
+					number = cell.number.takeIf { it != 0 },
 				)
 		}
 

--- a/domain/game/src/main/java/com/example/domain/game/usecases/SelectCellUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/SelectCellUseCase.kt
@@ -52,7 +52,7 @@ class SelectCellUseCase(
 			if (cell.number != 0) {
 				updatedSudoku =
 					highlightMatchingNumbersUseCase(
-						sudoku = updatedSudoku,
+						sudokuGrid = updatedSudoku,
 						number = cell.number,
 					)
 			}

--- a/domain/game/src/main/java/com/example/domain/game/usecases/UndoOperationUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/UndoOperationUseCase.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class UndoOperationUseCase(
 	private val operationRepository: OperationRepository,
 	private val inputNumberUseCase: InputNumberUseCase,
+	private val highlightMatchingNumbersUseCase: HighlightMatchingNumbersUseCase,
 ) {
 	private val mutex = Mutex()
 	private val isProcessing = AtomicBoolean(false)
@@ -63,6 +64,7 @@ class UndoOperationUseCase(
 							isNote = false,
 							isHint = oldCell.attributes.contains(CellAttributes.HINT_REVEALED),
 						)
+						updatedGrid = highlightMatchingNumbersUseCase(updatedGrid, oldCell.number)
 					}
 				}
 

--- a/domain/game/src/test/java/com/example/domain/game/usecases/InputNumberUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/InputNumberUseCaseTest.kt
@@ -1,0 +1,444 @@
+package com.example.domain.game.usecases
+
+import com.example.sudoku.model.CellAttributes
+import com.example.sudoku.model.SudokuCellData
+import com.example.sudoku.model.SudokuGrid
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class InputNumberUseCaseTest {
+	val inputNumberUseCase = InputNumberUseCase()
+
+	@Test
+	fun `Input number in a generated cell`() = runTest {
+		// Verify that attempting to input a number into a cell marked as GENERATED
+		// does not modify the SudokuGrid and returns the original grid.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 1,
+				attributes = persistentSetOf(
+					CellAttributes.GENERATED,
+				),
+			),
+		)
+		val updateGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 5,
+			row = 0,
+			column = 0,
+			isNote = false,
+			isHint = false,
+		)
+		assert(updateGrid.getCellAt(0, 0).number == 1)
+		assert(grid == updateGrid)
+	}
+
+	@Test
+	fun `Clear cell by inputting zero`() = runTest {
+		// Test that inputting '0' as the number clears the cell's number and corner notes.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 1,
+			),
+		)
+		val updateGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 0,
+			row = 0,
+			column = 0,
+			isNote = false,
+			isHint = false,
+		)
+		assert(updateGrid.getCellAt(0, 0).number == 0)
+		assert(updateGrid.getCellAt(0, 0).cornerNotes.isEmpty())
+	}
+
+	@Test
+	fun `Add a new corner note`() = runTest {
+		// When isNote is true and the number is not already in cornerNotes,
+		// verify that the number is added to the cell's cornerNotes and the cell's number is set to 0.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 1,
+				cornerNotes = persistentSetOf(),
+			),
+		)
+		val updatedGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 2,
+			row = 0,
+			column = 0,
+			isNote = true,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).cornerNotes == persistentSetOf(2))
+		assert(updatedGrid.getCellAt(0, 0).number == 0)
+	}
+
+	@Test
+	fun `Remove an existing corner note`() = runTest {
+		// When isNote is true and the number is already in cornerNotes,
+		// verify that the number is removed from the cell's cornerNotes and the cell's number is set to 0.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 0,
+				cornerNotes = persistentSetOf(2),
+			),
+		)
+		val updatedGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 2,
+			row = 0,
+			column = 0,
+			isNote = true,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).cornerNotes == persistentSetOf<Int>())
+		assert(updatedGrid.getCellAt(0, 0).number == 0)
+	}
+
+	@Test
+	fun `Input a new number  not a note `() = runTest {
+		// When isNote is false and the input number is different from the cell's current number,
+		// verify that the cell's number is updated to the input number and cornerNotes are cleared.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 3,
+				cornerNotes = persistentSetOf(1, 2, 3),
+			),
+		)
+		val updatedGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 1,
+			row = 0,
+			column = 0,
+			isNote = false,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).number == 1)
+		assert(updatedGrid.getCellAt(0, 0).cornerNotes == persistentSetOf<Int>())
+	}
+
+	@Test
+	fun `Clear cell by inputting existing number  not a note `() = runTest {
+		// When isNote is false and the input number is the same as the cell's current number,
+		// verify that the cell's number is set to 0 and cornerNotes are cleared.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 1,
+				cornerNotes = persistentSetOf(1, 2, 3),
+			),
+		)
+		val updatedGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 1,
+			row = 0,
+			column = 0,
+			isNote = false,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).number == 0)
+		assert(updatedGrid.getCellAt(0, 0).cornerNotes == persistentSetOf<Int>())
+	}
+
+	@Test
+	fun `Input number as a hint`() = runTest {
+		// When isHint is true and isNote is false,
+		// verify that the cell's number is updated and the HINT_REVEALED attribute is added.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 0,
+				cornerNotes = persistentSetOf(1, 2, 3),
+			),
+		)
+		val updatedGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 1,
+			row = 0,
+			column = 0,
+			isNote = false,
+			isHint = true,
+		)
+		assert(updatedGrid.getCellAt(0, 0).number == 1)
+		assert(
+			updatedGrid.getCellAt(
+				0,
+				0,
+			).attributes == persistentSetOf(CellAttributes.HINT_REVEALED),
+		)
+	}
+
+	@Test
+	fun `Input number not as a hint`() = runTest {
+		// When isHint is false and isNote is false,
+		// verify that the cell's number is updated and the HINT_REVEALED attribute is not added (or removed if present).
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 0,
+				cornerNotes = persistentSetOf(1, 2, 3),
+			),
+		)
+		val updatedGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 1,
+			row = 0,
+			column = 0,
+			isNote = false,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).number == 1)
+		assert(updatedGrid.getCellAt(0, 0).attributes == persistentSetOf<CellAttributes>())
+	}
+
+	@Test
+	fun `Corner notes are sorted after adding a new note`() = runTest {
+		// Verify that when a new corner note is added, the resulting cornerNotes set is sorted.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 0,
+				cornerNotes = persistentSetOf(2, 5),
+			),
+		)
+		var updatedGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 4,
+			row = 0,
+			column = 0,
+			isNote = true,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).cornerNotes == persistentSetOf(2, 4, 5))
+		updatedGrid = inputNumberUseCase(
+			sudokuGrid = updatedGrid,
+			number = 8,
+			row = 0,
+			column = 0,
+			isNote = true,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).cornerNotes == persistentSetOf(2, 4, 5, 8))
+		updatedGrid = inputNumberUseCase(
+			sudokuGrid = updatedGrid,
+			number = 1,
+			row = 0,
+			column = 0,
+			isNote = true,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).cornerNotes == persistentSetOf(1, 2, 4, 5, 8))
+	}
+
+	@Test
+	fun `Rule breaking cells are cleared and marked after input`() = runTest {
+		// After any valid input (not a generated cell),
+		// ensure that `clearRuleBreakingCells()` and `markRuleBreakingCells()` are called on the SudokuGrid.
+		val grid =
+			SudokuGrid().withReplacedCell(
+				row = 0,
+				col = 0,
+				cellData = SudokuCellData(
+					row = 0,
+					col = 0,
+					number = 1,
+				),
+			)
+
+		var updatedGrid =
+			inputNumberUseCase(
+				sudokuGrid = grid,
+				number = 1,
+				row = 1,
+				column = 0,
+				isNote = false,
+				isHint = false,
+			)
+
+		assert(updatedGrid.getCellAt(1, 0).number == 1)
+		assert(
+			updatedGrid.getCellAt(
+				1,
+				0,
+			).attributes == persistentSetOf(CellAttributes.RULE_BREAKING),
+		)
+		updatedGrid = inputNumberUseCase(
+			sudokuGrid = updatedGrid,
+			number = 2,
+			row = 1,
+			column = 0,
+			isNote = false,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(1, 0).number == 2)
+		assert(updatedGrid.getCellAt(1, 0).attributes == persistentSetOf<Int>())
+	}
+
+	@Test
+	fun `Concurrency  Multiple inputs to different cells`() {
+		// Test that multiple concurrent calls to `invoke` for different cells are handled correctly without race conditions,
+		// leveraging the Mutex.
+		// TODO implement test
+	}
+
+	@Test
+	fun `Concurrency  Multiple inputs to the same cell`() {
+		// Test that multiple concurrent calls to `invoke` for the same cell are serialized by the Mutex,
+		// and the final state of the cell reflects the sequential application of inputs.
+		// TODO implement test
+	}
+
+	@Test
+	fun `Edge case  Invalid row or column indices  out of bounds `() = runTest {
+		// Verify that providing row or column indices outside the valid grid dimensions
+		// (e.g., -1, or grid.size) is handled gracefully (e.g., throws an exception, as `getCellAt` likely would).
+		assertThrows<IllegalArgumentException> {
+			inputNumberUseCase(
+				sudokuGrid = SudokuGrid(),
+				number = 1,
+				row = -1,
+				column = 0,
+				isNote = false,
+				isHint = false,
+			)
+		}
+	}
+
+	@Test
+	fun `Inputting a note when the cell already has a number`() = runTest {
+		// When isNote is true, and the cell currently has a number (not 0),
+		// verify that the existing number is set to 0 and the note is added/removed as expected.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 1,
+			),
+		)
+		val updatedGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 2,
+			row = 0,
+			column = 0,
+			isNote = true,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).number == 0)
+		assert(updatedGrid.getCellAt(0, 0).cornerNotes == persistentSetOf(2))
+	}
+
+	@Test
+	fun `Inputting a number when the cell has existing notes`() = runTest {
+		// When isNote is false and a number is inputted,
+		// verify that any existing corner notes in the cell are cleared.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 0,
+				cornerNotes = persistentSetOf(1, 2, 3),
+			),
+		)
+		val updatedGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 1,
+			row = 0,
+			column = 0,
+			isNote = false,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).number == 1)
+		assert(updatedGrid.getCellAt(0, 0).cornerNotes == persistentSetOf<Int>())
+	}
+
+	@Test
+	fun `Inputting zero as a note`() = runTest {
+		// When number is 0 and isNote is true, verify that the cell's number is set to 0 and corner notes are cleared
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 0,
+				cornerNotes = persistentSetOf(1, 2, 3),
+			),
+		)
+		val updatedGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 0,
+			row = 0,
+			column = 0,
+			isNote = true,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).number == 0)
+		assert(updatedGrid.getCellAt(0, 0).cornerNotes == persistentSetOf<Int>())
+	}
+
+	@Test
+	fun `Cell already has HINT REVEALED attribute and isHint is false`() = runTest {
+		// If a cell has HINT_REVEALED and a regular number is input (isHint=false),
+		// ensure the HINT_REVEALED attribute is removed.
+		val grid = SudokuGrid().withReplacedCell(
+			row = 0,
+			col = 0,
+			cellData = SudokuCellData(
+				row = 0,
+				col = 0,
+				number = 1,
+				attributes = persistentSetOf(CellAttributes.HINT_REVEALED),
+			),
+		)
+		val updatedGrid = inputNumberUseCase(
+			sudokuGrid = grid,
+			number = 2,
+			row = 0,
+			column = 0,
+			isNote = false,
+			isHint = false,
+		)
+		assert(updatedGrid.getCellAt(0, 0).number == 2)
+		assert(updatedGrid.getCellAt(0, 0).attributes == persistentSetOf<Int>())
+	}
+}

--- a/domain/game/src/test/java/com/example/domain/game/usecases/RedoOperationUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/RedoOperationUseCaseTest.kt
@@ -14,6 +14,7 @@ import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -30,6 +31,7 @@ class RedoOperationUseCaseTest {
 
 	private lateinit var operationRepository: OperationRepository
 	private lateinit var inputNumberUseCase: InputNumberUseCase
+	private lateinit var highlightMatchingNumbersUseCase: HighlightMatchingNumbersUseCase
 	private lateinit var redoOperationUseCase: RedoOperationUseCase
 
 	private val initialGrid = SudokuGrid()
@@ -39,11 +41,19 @@ class RedoOperationUseCaseTest {
 	fun setUp() {
 		operationRepository = mockk()
 		inputNumberUseCase = mockk()
-		redoOperationUseCase = spyk(RedoOperationUseCase(operationRepository, inputNumberUseCase))
+		highlightMatchingNumbersUseCase = mockk()
+		redoOperationUseCase = spyk(
+			RedoOperationUseCase(
+				operationRepository,
+				inputNumberUseCase,
+				highlightMatchingNumbersUseCase,
+			),
+		)
 
 		coJustRun { operationRepository.addUndoOperation(any()) }
 		coEvery { operationRepository.findRedoOperation(any()) } returns mockk { every { id } returns 1L }
 		coJustRun { operationRepository.removeRedoOperation(any()) }
+		every { highlightMatchingNumbersUseCase(any(), any()) } returns updatedGrid
 		coEvery {
 			inputNumberUseCase.invoke(
 				sudokuGrid = any(),
@@ -135,10 +145,23 @@ class RedoOperationUseCaseTest {
 		val lastOperation = Operation(1, oldCell changedTo newCell)
 		val gridAfterNote1 = SudokuGrid().withValue(0, 0, 1) // Dummy grid
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
-		coEvery { inputNumberUseCase(any(), 1, any(), any(), true, any()) } returns gridAfterNote1
+		coEvery {
+			inputNumberUseCase(
+				any(),
+				1,
+				any(),
+				any(),
+				true,
+				any(),
+			)
+		} returns gridAfterNote1
 		coEvery { inputNumberUseCase(any(), 2, any(), any(), true, any()) } returns updatedGrid
 
-		val redoUseCase = RedoOperationUseCase(operationRepository, inputNumberUseCase)
+		val redoUseCase = RedoOperationUseCase(
+			operationRepository,
+			inputNumberUseCase,
+			highlightMatchingNumbersUseCase,
+		)
 		val result = redoUseCase(initialGrid)
 
 		assertEquals(updatedGrid, result)
@@ -291,5 +314,18 @@ class RedoOperationUseCaseTest {
 				inputNumberUseCase(any(), any(), any(), any(), any(), any())
 			} throws RuntimeException("Input error")
 		}
+	}
+
+	@Test
+	fun `RedoOperationUseCase highlight matching numbers`() = runTest {
+		/**
+		 * Test that `highlightMatchingNumbersUseCase` is called after a successful redo operation.
+		 * This ensures that after a number is redone, the UI correctly highlights matching numbers.
+		 */
+		val lastOperation = Operation(1, SudokuCellData(0, 0, 5) changedTo SudokuCellData(0, 0, 0))
+		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
+		redoOperationUseCase(initialGrid)
+
+		verify(exactly = 1) { highlightMatchingNumbersUseCase(any(), 0) }
 	}
 }

--- a/domain/game/src/test/java/com/example/domain/game/usecases/SelectCellUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/SelectCellUseCaseTest.kt
@@ -15,7 +15,6 @@ class SelectCellUseCaseTest {
 	private lateinit var selectCellUseCase: SelectCellUseCase
 	private lateinit var highlightRowAndColumnUseCase: HighlightRowAndColumnUseCase
 	private lateinit var highlightMatchingNumbersUseCase: HighlightMatchingNumbersUseCase
-	private lateinit var clearHighlightedNumbersUseCase: ClearHighlightedNumbersUseCase
 	private lateinit var clearHighlightedRowAndColumnUseCase: ClearHighlightedRowAndColumnUseCase
 
 	private val emptyGrid = SudokuGrid(9)
@@ -28,9 +27,6 @@ class SelectCellUseCaseTest {
 		highlightMatchingNumbersUseCase = mockk(relaxed = true) {
 			every { this@mockk.invoke(any(), any()) } answers { firstArg() }
 		}
-		clearHighlightedNumbersUseCase = mockk(relaxed = true) {
-			every { this@mockk.invoke(any()) } answers { firstArg() }
-		}
 		clearHighlightedRowAndColumnUseCase = mockk(relaxed = true) {
 			every { this@mockk.invoke(any()) } answers { firstArg() }
 		}
@@ -39,7 +35,6 @@ class SelectCellUseCaseTest {
 			SelectCellUseCase(
 				highlightRowAndColumnUseCase,
 				highlightMatchingNumbersUseCase,
-				clearHighlightedNumbersUseCase,
 				clearHighlightedRowAndColumnUseCase,
 			)
 	}
@@ -58,10 +53,9 @@ class SelectCellUseCaseTest {
 		val resultGrid = selectCellUseCase(initialGrid, null)
 
 		assert(!resultGrid.getCellAt(0, 0).attributes.contains(CellAttributes.SELECTED))
-		verify { clearHighlightedNumbersUseCase(any()) }
 		verify { clearHighlightedRowAndColumnUseCase(any()) }
 		verify(exactly = 0) { highlightRowAndColumnUseCase(any(), any(), any()) }
-		verify(exactly = 0) { highlightMatchingNumbersUseCase(any(), any()) }
+		verify(exactly = 1) { highlightMatchingNumbersUseCase(any(), any()) }
 	}
 
 	@Test
@@ -258,7 +252,7 @@ class SelectCellUseCaseTest {
 		selectCellUseCase(gridWithHighlights, emptyCellToSelect)
 
 		// 3. Verify that clearHighlightedNumbersUseCase was NOT called
-		verify(exactly = 0) { clearHighlightedNumbersUseCase(any()) }
+		verify(exactly = 0) { highlightMatchingNumbersUseCase(any(), null) }
 	}
 
 	@Test

--- a/domain/game/src/test/java/com/example/domain/game/usecases/SelectCellUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/SelectCellUseCaseTest.kt
@@ -1,0 +1,304 @@
+package com.example.domain.game.usecases
+
+import com.example.sudoku.model.CellAttributes
+import com.example.sudoku.model.SudokuGrid
+import com.example.sudoku.model.addAttribute
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.collections.immutable.persistentSetOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SelectCellUseCaseTest {
+	private lateinit var selectCellUseCase: SelectCellUseCase
+	private lateinit var highlightRowAndColumnUseCase: HighlightRowAndColumnUseCase
+	private lateinit var highlightMatchingNumbersUseCase: HighlightMatchingNumbersUseCase
+	private lateinit var clearHighlightedNumbersUseCase: ClearHighlightedNumbersUseCase
+	private lateinit var clearHighlightedRowAndColumnUseCase: ClearHighlightedRowAndColumnUseCase
+
+	private val emptyGrid = SudokuGrid(9)
+
+	@BeforeEach
+	fun setUp() {
+		highlightRowAndColumnUseCase = mockk(relaxed = true) {
+			every { this@mockk.invoke(any(), any(), any()) } answers { firstArg() }
+		}
+		highlightMatchingNumbersUseCase = mockk(relaxed = true) {
+			every { this@mockk.invoke(any(), any()) } answers { firstArg() }
+		}
+		clearHighlightedNumbersUseCase = mockk(relaxed = true) {
+			every { this@mockk.invoke(any()) } answers { firstArg() }
+		}
+		clearHighlightedRowAndColumnUseCase = mockk(relaxed = true) {
+			every { this@mockk.invoke(any()) } answers { firstArg() }
+		}
+
+		selectCellUseCase =
+			SelectCellUseCase(
+				highlightRowAndColumnUseCase,
+				highlightMatchingNumbersUseCase,
+				clearHighlightedNumbersUseCase,
+				clearHighlightedRowAndColumnUseCase,
+			)
+	}
+
+	@Test
+	fun `SelectCellUseCase selectedCell is null`() {
+		// Verify that when selectedCell is null, the SudokuGrid is returned with previously selected cells deselected and highlights cleared.
+		val initialGrid =
+			emptyGrid.withReplacedCell(
+				0,
+				0,
+				emptyGrid.getCellAt(0, 0)
+					.copy(attributes = persistentSetOf(CellAttributes.SELECTED)),
+			)
+
+		val resultGrid = selectCellUseCase(initialGrid, null)
+
+		assert(!resultGrid.getCellAt(0, 0).attributes.contains(CellAttributes.SELECTED))
+		verify { clearHighlightedNumbersUseCase(any()) }
+		verify { clearHighlightedRowAndColumnUseCase(any()) }
+		verify(exactly = 0) { highlightRowAndColumnUseCase(any(), any(), any()) }
+		verify(exactly = 0) { highlightMatchingNumbersUseCase(any(), any()) }
+	}
+
+	@Test
+	fun `SelectCellUseCase selectedCell is not null  cell has no initial attributes`() {
+		// Verify that when a valid cell is selected, it's marked as SELECTED, and row, column, and matching numbers are highlighted.
+		// The selected cell initially has no attributes.
+		val selectedCell = 1 to 2
+
+		val resultGrid = selectCellUseCase(emptyGrid, selectedCell)
+
+		assert(
+			resultGrid.getCellAt(selectedCell.first, selectedCell.second).attributes.contains(
+				CellAttributes.SELECTED,
+			),
+		)
+		verify { highlightRowAndColumnUseCase(any(), selectedCell.first, selectedCell.second) }
+	}
+
+	@Test
+	fun `SelectCellUseCase selectedCell is not null  cell has other attributes`() {
+		// Verify that when a valid cell with pre-existing attributes is selected, the SELECTED attribute is added without removing existing ones,
+		// and row, column, and matching numbers are highlighted.
+		val selectedCell = 1 to 2
+		val otherAttribute = CellAttributes.GENERATED
+		val initialGrid =
+			emptyGrid.withReplacedCell(
+				selectedCell.first,
+				selectedCell.second,
+				emptyGrid.getCellAt(selectedCell.first, selectedCell.second)
+					.copy(attributes = persistentSetOf(otherAttribute)),
+			)
+
+		val resultGrid = selectCellUseCase(initialGrid, selectedCell)
+
+		assert(
+			resultGrid.getCellAt(selectedCell.first, selectedCell.second).attributes.contains(
+				CellAttributes.SELECTED,
+			),
+		)
+		assert(
+			resultGrid.getCellAt(selectedCell.first, selectedCell.second).attributes.contains(
+				otherAttribute,
+			),
+		)
+	}
+
+	@Test
+	fun `SelectCellUseCase selecting a new cell when another cell is already selected`() {
+		// Verify that if a cell is already selected, selecting a new cell correctly deselects the old one, clears its highlights,
+		// and selects and highlights the new cell and its related elements.
+		val oldSelectedCell = 0 to 0
+		val newSelectedCell = 1 to 1
+		val initialGrid =
+			emptyGrid.withReplacedCell(
+				oldSelectedCell.first,
+				oldSelectedCell.second,
+				emptyGrid.getCellAt(oldSelectedCell.first, oldSelectedCell.second)
+					.copy(attributes = persistentSetOf(CellAttributes.SELECTED)),
+			)
+
+		val resultGrid = selectCellUseCase(initialGrid, newSelectedCell)
+
+		assert(
+			!resultGrid.getCellAt(
+				oldSelectedCell.first,
+				oldSelectedCell.second,
+			).attributes.contains(
+				CellAttributes.SELECTED,
+			),
+		)
+		assert(
+			resultGrid.getCellAt(newSelectedCell.first, newSelectedCell.second).attributes.contains(
+				CellAttributes.SELECTED,
+			),
+		)
+		verify {
+			highlightRowAndColumnUseCase(
+				any(),
+				newSelectedCell.first,
+				newSelectedCell.second,
+			)
+		}
+	}
+
+	@Test
+	fun `SelectCellUseCase selected cell has a number`() {
+		// Verify that highlightMatchingNumbersUseCase is called with the correct number from the selected cell.
+		val selectedCell = 3 to 4
+		val number = 5
+		val initialGrid = emptyGrid.withValue(selectedCell.first, selectedCell.second, number)
+
+		selectCellUseCase(initialGrid, selectedCell)
+
+		verify { highlightMatchingNumbersUseCase(any(), number) }
+	}
+
+	@Test
+	fun `SelectCellUseCase selected cell is empty  number is null or 0 `() {
+		// Verify that highlightMatchingNumbersUseCase is called with null or 0 if the selected cell is empty, and handles it gracefully (no numbers highlighted).
+		val selectedCell = 2 to 2
+		val cell = emptyGrid.getCellAt(selectedCell.first, selectedCell.second)
+		assert(cell.number == 0)
+
+		selectCellUseCase(emptyGrid, selectedCell)
+
+		verify(exactly = 0) { highlightMatchingNumbersUseCase(any(), any()) }
+	}
+
+	@Test
+	fun `SelectCellUseCase SudokuGrid has pre existing selected cells`() {
+		// Verify that any cells in the input SudokuGrid that are already marked with CellAttributes.SELECTED are correctly deselected before processing the new selectedCell.
+		val preSelectedCell = 4 to 4
+		val newSelectedCell = 5 to 5
+		val initialGrid =
+			emptyGrid.withReplacedCell(
+				preSelectedCell.first,
+				preSelectedCell.second,
+				emptyGrid.getCellAt(preSelectedCell.first, preSelectedCell.second)
+					.copy(attributes = persistentSetOf(CellAttributes.SELECTED)),
+			)
+
+		val resultGrid = selectCellUseCase(initialGrid, newSelectedCell)
+
+		assert(
+			!resultGrid.getCellAt(
+				preSelectedCell.first,
+				preSelectedCell.second,
+			).attributes.contains(
+				CellAttributes.SELECTED,
+			),
+		)
+		assert(
+			resultGrid.getCellAt(
+				newSelectedCell.first,
+				newSelectedCell.second,
+			).attributes.contains(CellAttributes.SELECTED),
+		)
+	}
+
+	@Test
+	fun `SelectCellUseCase interaction with highlightRowAndColumnUseCase`() {
+		// Ensure highlightRowAndColumnUseCase is called with the correct SudokuGrid (after deselection and clearing) and the correct row/column from selectedCell.
+		val selectedCell = 2 to 3
+		selectCellUseCase(emptyGrid, selectedCell)
+
+		verifyOrder {
+			clearHighlightedRowAndColumnUseCase(any())
+			highlightRowAndColumnUseCase(any(), selectedCell.first, selectedCell.second)
+		}
+	}
+
+	@Test
+	fun `SelectCellUseCase interaction with highlightMatchingNumbersUseCase`() {
+		// Ensure highlightMatchingNumbersUseCase is called with the correct SudokuGrid (after selection and row/column highlighting) and the correct number from the selected cell.
+		val selectedCell = 2 to 3
+		val number = 7
+		val initialGrid = emptyGrid.withValue(selectedCell.first, selectedCell.second, number)
+
+		selectCellUseCase(initialGrid, selectedCell)
+
+		verifyOrder {
+			highlightRowAndColumnUseCase(any(), selectedCell.first, selectedCell.second)
+			highlightMatchingNumbersUseCase(any(), number)
+		}
+	}
+
+	@Test
+	fun `SelectCellUseCase immutability of input SudokuGrid`() {
+		// Confirm that the original sudoku object passed to the invoke method is not mutated, and a new instance is returned.
+		val initialGrid = emptyGrid.withValue(0, 0, 5)
+		val initialGridCopy = initialGrid.copy()
+
+		val resultGrid = selectCellUseCase(initialGrid, 1 to 1)
+
+		assert(resultGrid != initialGrid)
+		assert(initialGrid == initialGridCopy) // No mutation
+	}
+
+	@Test
+	fun `selecting an empty cell should not clear existing number highlights`() {
+		// 1. Setup a grid with some highlighted numbers
+		val gridWithHighlights =
+			emptyGrid.addAttribute({ it.row == 0 }, CellAttributes.NUMBER_MATCH_HIGHLIGHTED)
+
+		// 2. Select an empty cell
+		val emptyCellToSelect = 1 to 1
+		assert(
+			gridWithHighlights.getCellAt(
+				emptyCellToSelect.first,
+				emptyCellToSelect.second,
+			).number == 0,
+		)
+
+		selectCellUseCase(gridWithHighlights, emptyCellToSelect)
+
+		// 3. Verify that clearHighlightedNumbersUseCase was NOT called
+		verify(exactly = 0) { clearHighlightedNumbersUseCase(any()) }
+	}
+
+	@Test
+	fun `SelectCellUseCase with an empty SudokuGrid  all cells empty `() {
+		// Test behavior when a cell is selected in an entirely empty Sudoku grid.
+		val selectedCell = 0 to 0
+		val resultGrid = selectCellUseCase(emptyGrid, selectedCell)
+
+		assert(
+			resultGrid.getCellAt(
+				selectedCell.first,
+				selectedCell.second,
+			).attributes.contains(CellAttributes.SELECTED),
+		)
+
+		verify { highlightRowAndColumnUseCase(any(), selectedCell.first, selectedCell.second) }
+		verify(exactly = 0) { highlightMatchingNumbersUseCase(any(), any()) }
+	}
+
+	@Test
+	fun `SelectCellUseCase with a fully solved SudokuGrid`() {
+		// Test behavior when a cell is selected in a fully solved Sudoku grid, ensuring highlights work as expected.
+		// Create a simple solved grid
+		var solvedGrid: SudokuGrid = emptyGrid
+		for (i in 0..8) {
+			solvedGrid = solvedGrid.withValue(i, i, i + 1)
+		}
+		val selectedCell = 4 to 4
+		val selectedNumber = solvedGrid.getCellAt(selectedCell.first, selectedCell.second).number
+
+		val resultGrid = selectCellUseCase(solvedGrid, selectedCell)
+
+		assert(
+			resultGrid.getCellAt(
+				selectedCell.first,
+				selectedCell.second,
+			).attributes.contains(CellAttributes.SELECTED),
+		)
+
+		verify { highlightRowAndColumnUseCase(any(), selectedCell.first, selectedCell.second) }
+		verify { highlightMatchingNumbersUseCase(any(), selectedNumber) }
+	}
+}

--- a/domain/game/src/test/java/com/example/domain/game/usecases/UndoOperationUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/UndoOperationUseCaseTest.kt
@@ -14,6 +14,7 @@ import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -31,6 +32,7 @@ class UndoOperationUseCaseTest {
 	private lateinit var operationRepository: OperationRepository
 	private lateinit var inputNumberUseCase: InputNumberUseCase
 	private lateinit var undoOperationUseCase: UndoOperationUseCase
+	private lateinit var highlightMatchingNumbersUseCase: HighlightMatchingNumbersUseCase
 
 	private val initialGrid = SudokuGrid()
 	private val updatedGrid = SudokuGrid().withValue(0, 0, 1)
@@ -39,11 +41,19 @@ class UndoOperationUseCaseTest {
 	fun setUp() {
 		operationRepository = mockk()
 		inputNumberUseCase = mockk()
-		undoOperationUseCase = spyk(UndoOperationUseCase(operationRepository, inputNumberUseCase))
+		highlightMatchingNumbersUseCase = mockk()
+		undoOperationUseCase = spyk(
+			UndoOperationUseCase(
+				operationRepository,
+				inputNumberUseCase,
+				highlightMatchingNumbersUseCase,
+			),
+		)
 
 		coJustRun { operationRepository.addRedoOperation(any()) }
 		coEvery { operationRepository.findUndoOperation(any()) } returns mockk { every { id } returns 1L }
 		coJustRun { operationRepository.removeUndoOperation(any()) }
+		coEvery { highlightMatchingNumbersUseCase(any(), any()) } returns updatedGrid
 		coEvery {
 			inputNumberUseCase.invoke(
 				sudokuGrid = any(),
@@ -417,5 +427,23 @@ class UndoOperationUseCaseTest {
 		undoOperationUseCase(initialGrid)
 
 		coVerify { inputNumberUseCase(initialGrid, 0, 0, 0, isNote = false, isHint = false) }
+	}
+
+	@Test
+	fun `UndoOperationUseCase highlight matching numbers`() = runTest {
+		/**
+		 * Test that after a successful undo operation that results in a cell having a number (0 in this case, representing empty),
+		 * the `highlightMatchingNumbersUseCase` is called to update the highlighting of numbers in the grid.
+		 */
+		val oldCell = SudokuCellData(0, 0, 0)
+		val newCell = SudokuCellData(0, 0, 5)
+		val lastOperation = Operation(1, oldCell changedTo newCell)
+		coEvery { operationRepository.getUndoOperations() } returns listOf(lastOperation)
+
+		undoOperationUseCase(initialGrid)
+
+		verify(exactly = 1) {
+			highlightMatchingNumbersUseCase(any(), 0)
+		}
 	}
 }

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -300,6 +300,12 @@ internal class SudokuGameViewModel(
 					isNote = isNote,
 					isHint = isHint,
 				)
+			if (!isNote && !isHint) {
+				updatedSudoku = gameManagementUseCases.highlightMatching(
+					sudokuGrid = updatedSudoku,
+					number = number,
+				)
+			}
 			changes.add(
 				CellChange(
 					oldCell = backupCell,


### PR DESCRIPTION
This pull request updates `HighlightMatchingNumbersUseCase` and integrates it into various game-related use cases. It simplifies the codebase by removing redundant logic and ensures that number highlighting functionality is consistently applied across operations like cell selection, undo, and redo. Additionally, it updates related tests to cover the new behavior.

### Feature Addition and Integration:
* Updated `HighlightMatchingNumbersUseCase` to also clear highlighted numberse. This use case now replaces the removed `ClearHighlightedNumbersUseCase` and simplifies the logic by leveraging helper methods like `clearMatchingNumberHighlight` and `highlightMatchingCells` in `SudokuGrid`. (`[[1]](diffhunk://#diff-1cafa6d2457ec0b1c38af71d641338ef5f55b713cf0cb8a16bda6baa15bb387eR8)`, `[[2]](diffhunk://#diff-c29f8df5546261137ba331e98dd5876fd9fdfcc3755a73a44b3bfa3ef7494932L3-L36)`)
* Integrated `HighlightMatchingNumbersUseCase` into `SelectCellUseCase`, `UndoOperationUseCase`, and `RedoOperationUseCase` to ensure consistent highlighting of matching numbers during these operations. (`[[1]](diffhunk://#diff-f97d44336ce3b1437b67b2083ec01f7f3e7de6bc261111998399739097995ac6L38-L40)`, `[[2]](diffhunk://#diff-ea067d951e544d9881ecacbed41e3771df819a7402d8e0593c0e982289370406R67)`, `[[3]](diffhunk://#diff-71a6359f6f938b24339fcdb48c94a34e28d1cb7c31fc381547109d990306a7d0R70)`, `[[4]](diffhunk://#diff-0079210cb73a58133ae3b838aa112b706c51b0a2d8a3e21c1eab8530be264b18L21-R34)`)

### Dependency Injection Updates:
* Updated the dependency injection module (`domainGameModule`) to include `HighlightMatchingNumbersUseCase` and removed references to the deprecated `ClearHighlightedNumbersUseCase`. Adjusted factory methods for `SelectCellUseCase`, `UndoOperationUseCase`, and `RedoOperationUseCase` to inject the new use case. (`[[1]](diffhunk://#diff-f97d44336ce3b1437b67b2083ec01f7f3e7de6bc261111998399739097995ac6L54-R71)`, `[[2]](diffhunk://#diff-f97d44336ce3b1437b67b2083ec01f7f3e7de6bc261111998399739097995ac6R92)`)

### Testing Enhancements:
* Added tests to verify the behavior of `HighlightMatchingNumbersUseCase` integration, ensuring that matching numbers are correctly highlighted during redo operations. (`[domain/game/src/test/java/com/example/domain/game/usecases/RedoOperationUseCaseTest.ktR318-R330](diffhunk://#diff-a86ea5e14c0f9ca7ef146b43036e0162b21c4ef2a10a21617ce35923cb4d8325R318-R330)`)
* Updated existing tests for `RedoOperationUseCase` to accommodate the new dependency and validate its behavior. (`[[1]](diffhunk://#diff-a86ea5e14c0f9ca7ef146b43036e0162b21c4ef2a10a21617ce35923cb4d8325R34)`, `[[2]](diffhunk://#diff-a86ea5e14c0f9ca7ef146b43036e0162b21c4ef2a10a21617ce35923cb4d8325L138-R164)`)