### PR TITLE
Feat/toggle highlight matching

### DIFF
--- a/app/src/test/java/com/example/sudokuslayer/CheckModulesTest.kt
+++ b/app/src/test/java/com/example/sudokuslayer/CheckModulesTest.kt
@@ -16,9 +16,6 @@ class CheckModulesTest : KoinTest {
 				definition<com.example.data.core.database.AndroidDatabaseDriverFactory>(
 					android.content.Context::class,
 				),
-				definition<com.example.feature.settings.SettingsViewModel>(
-					androidx.lifecycle.SavedStateHandle::class,
-				),
 			),
 		)
 	}

--- a/data/settings/src/main/java/com/example/data/settings/AndroidSettingsRepository.kt
+++ b/data/settings/src/main/java/com/example/data/settings/AndroidSettingsRepository.kt
@@ -38,7 +38,8 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 		it == true
 	}
 	override val showActionButtonsOnTop: Flow<Boolean> =
-		preferenceStorage.getAsFlow(SettingsPreferenceKeys.ShowActionButtonsOnTop).map { it == true }
+		preferenceStorage.getAsFlow(SettingsPreferenceKeys.ShowActionButtonsOnTop)
+			.map { it == true }
 
 	override val insightsSummaryCompactLayout: Flow<Boolean> = preferenceStorage.getAsFlow(
 		SettingsPreferenceKeys.InsightsSummaryCompactLayout,
@@ -46,6 +47,10 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 
 	override val autoClearNotes: Flow<Boolean> = preferenceStorage.getAsFlow(
 		SettingsPreferenceKeys.AutoClearNotes,
+	).map { it == true }
+
+	override val highlightMatchingNumbers: Flow<Boolean> = preferenceStorage.getAsFlow(
+		SettingsPreferenceKeys.HighlightMatchingNumbers,
 	).map { it == true }
 
 	override suspend fun setDarkMode(darkMode: DarkMode) {
@@ -78,6 +83,13 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 
 	override suspend fun setAutoClearNotes(autoClearNotes: Boolean) {
 		preferenceStorage.set(SettingsPreferenceKeys.AutoClearNotes, autoClearNotes)
+	}
+
+	override suspend fun setHighlightMatchingNumbers(highlightMatchingNumbers: Boolean) {
+		preferenceStorage.set(
+			SettingsPreferenceKeys.HighlightMatchingNumbers,
+			highlightMatchingNumbers,
+		)
 	}
 
 	override fun getAvailableColorSchemes(): List<ColorScheme> = ColorScheme.getAvailableColorSchemes()

--- a/data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.kt
+++ b/data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.kt
@@ -38,4 +38,9 @@ interface SettingsPreferenceKeys {
 		name = "auto_clear_notes",
 		defaultValue = true,
 	)
+
+	data object HighlightMatchingNumbers : PreferenceStorage.Key.BooleanKey(
+		name = "highlight_matching_numbers",
+		defaultValue = true,
+	)
 }

--- a/domain/game/build.gradle.kts
+++ b/domain/game/build.gradle.kts
@@ -5,5 +5,6 @@ plugins {
 dependencies {
 	api(projects.sudokuCore)
 	api(projects.domain.core)
-	implementation(project(":domain:statistics"))
+	implementation(projects.domain.statistics)
+	implementation(projects.domain.settings)
 }

--- a/domain/game/src/main/java/com/example/domain/game/Module.kt
+++ b/domain/game/src/main/java/com/example/domain/game/Module.kt
@@ -41,7 +41,7 @@ val domainGameModule =
 				clearHighlightedRowAndColumnUseCase = get(),
 			)
 		}
-		factory { HighlightMatchingNumbersUseCase() }
+		factory { HighlightMatchingNumbersUseCase(get()) }
 		factory { HighlightRowAndColumnUseCase() }
 		factory { ClearHighlightedRowAndColumnUseCase() }
 

--- a/domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.kt
@@ -4,11 +4,13 @@ import com.example.domain.settings.SettingsRepository
 import com.example.sudoku.model.SudokuGrid
 import com.example.sudoku.model.clearMatchingNumberHighlight
 import com.example.sudoku.model.highlightMatchingCells
+import kotlinx.coroutines.flow.firstOrNull
 
 class HighlightMatchingNumbersUseCase(private val settingsRepository: SettingsRepository) {
-	operator fun invoke(sudokuGrid: SudokuGrid, number: Int?): SudokuGrid {
+	suspend operator fun invoke(sudokuGrid: SudokuGrid, number: Int?): SudokuGrid {
 		val clearedGrid = sudokuGrid.clearMatchingNumberHighlight()
-		return if (number != null && number != 0) {
+		val highlightMatchingNumbers = settingsRepository.highlightMatchingNumbers.firstOrNull() ?: true
+		return if (number != null && number != 0 && highlightMatchingNumbers) {
 			clearedGrid.highlightMatchingCells(number)
 		} else {
 			clearedGrid

--- a/domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.kt
@@ -1,10 +1,11 @@
 package com.example.domain.game.usecases
 
+import com.example.domain.settings.SettingsRepository
 import com.example.sudoku.model.SudokuGrid
 import com.example.sudoku.model.clearMatchingNumberHighlight
 import com.example.sudoku.model.highlightMatchingCells
 
-class HighlightMatchingNumbersUseCase {
+class HighlightMatchingNumbersUseCase(private val settingsRepository: SettingsRepository) {
 	operator fun invoke(sudokuGrid: SudokuGrid, number: Int?): SudokuGrid {
 		val clearedGrid = sudokuGrid.clearMatchingNumberHighlight()
 		return if (number != null && number != 0) {

--- a/domain/game/src/main/java/com/example/domain/game/usecases/SelectCellUseCase.kt
+++ b/domain/game/src/main/java/com/example/domain/game/usecases/SelectCellUseCase.kt
@@ -10,7 +10,7 @@ class SelectCellUseCase(
 	private val highlightMatchingNumbersUseCase: HighlightMatchingNumbersUseCase,
 	private val clearHighlightedRowAndColumnUseCase: ClearHighlightedRowAndColumnUseCase,
 ) {
-	operator fun invoke(sudoku: SudokuGrid, selectedCell: Pair<Int, Int>? = null): SudokuGrid {
+	suspend operator fun invoke(sudoku: SudokuGrid, selectedCell: Pair<Int, Int>? = null): SudokuGrid {
 		var updatedSudoku =
 			sudoku.removeAttribute(
 				predicate = { cell -> cell.attributes.contains(CellAttributes.SELECTED) },

--- a/domain/game/src/test/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCaseTest.kt
@@ -1,0 +1,254 @@
+package com.example.domain.game.usecases
+
+import com.example.domain.settings.SettingsRepository
+import com.example.sudoku.model.CellAttributes
+import com.example.sudoku.model.SudokuGrid
+import com.example.sudoku.model.updateCells
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.plus
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class HighlightMatchingNumbersUseCaseTest {
+
+	@RelaxedMockK
+	private lateinit var mockSettingsRepository: SettingsRepository
+
+	private lateinit var useCase: HighlightMatchingNumbersUseCase
+
+	private val sampleGridData = listOf(
+		intArrayOf(1, 2, 0, 0),
+		intArrayOf(3, 4, 1, 0),
+		intArrayOf(0, 1, 0, 2),
+		intArrayOf(0, 0, 4, 1),
+	)
+
+	@BeforeEach
+	fun setUp() {
+		MockKAnnotations.init(this)
+		useCase = HighlightMatchingNumbersUseCase(mockSettingsRepository)
+
+		every { mockSettingsRepository.highlightMatchingNumbers } returns flowOf(true)
+	}
+
+	private fun createGridWithHighlight(numberToHighlight: Int): SudokuGrid {
+		val baseGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
+		return baseGrid.updateCells(
+			predicate = { it.number == numberToHighlight },
+			transform = { it.copy(attributes = it.attributes + CellAttributes.NUMBER_MATCH_HIGHLIGHTED) },
+		)
+	}
+
+	@Test
+	fun `Highlighting matching numbers with valid number`() {
+		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
+		val numberToHighlight = 1
+
+		val resultGrid = useCase(initialGrid, numberToHighlight)
+
+		resultGrid.data.forEach { cell ->
+			if (cell.number == numberToHighlight) {
+				assertTrue(
+					cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+					"Cell at (${cell.row}, ${cell.col}) with number $numberToHighlight should be highlighted.",
+				)
+			} else {
+				assertFalse(
+					cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+					"Cell at (${cell.row}, ${cell.col}) with number ${cell.number} should not be highlighted.",
+				)
+			}
+		}
+	}
+
+	@Test
+	fun `Highlighting with null number`() {
+		val initialGridWithHighlights =
+			createGridWithHighlight(1) // Start with some cells highlighted
+		assertTrue(
+			initialGridWithHighlights.data.any {
+				it.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED)
+			},
+		)
+
+		val resultGrid = useCase(initialGridWithHighlights, null)
+
+		resultGrid.data.forEach { cell ->
+			assertFalse(
+				cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+				"Cell at (${cell.row}, ${cell.col}) should not have number match highlight when input is null.",
+			)
+		}
+	}
+
+	@Test
+	fun `Highlighting with zero as number`() {
+		val initialGridWithHighlights =
+			createGridWithHighlight(2) // Start with some cells highlighted
+		assertTrue(
+			initialGridWithHighlights.data.any {
+				it.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED)
+			},
+		)
+
+		val resultGrid = useCase(initialGridWithHighlights, 0)
+
+		resultGrid.data.forEach { cell ->
+			assertFalse(
+				cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+				"Cell at (${cell.row}, ${cell.col}) should not have number match highlight when input is 0.",
+			)
+		}
+	}
+
+	@Test
+	fun `Grid state after clearing highlights`() {
+		// Create a grid with cell (0,0) value 1 and already highlighted
+		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
+			.updateCell(
+				0,
+				0,
+			) { it.copy(attributes = persistentSetOf(CellAttributes.NUMBER_MATCH_HIGHLIGHTED)) }
+
+		// Highlight a different number, e.g., 2. This should clear previous highlight on 1.
+		val numberToHighlight = 2
+		val resultGrid = useCase(initialGrid, numberToHighlight)
+
+		val cell00 = resultGrid.getCellAt(0, 0)
+		assertFalse(
+			cell00.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+			"Previously highlighted cell (0,0) for number 1 should be cleared.",
+		)
+
+		resultGrid.data.filter { it.number == numberToHighlight }.forEach { cell ->
+			assertTrue(
+				cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+				"Cell with number $numberToHighlight should be highlighted.",
+			)
+		}
+	}
+
+	@Test
+	fun `Grid state with no matching numbers`() {
+		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
+		val numberToHighlight = 5 // This number is not in sampleGridData
+
+		val resultGrid = useCase(initialGrid, numberToHighlight)
+
+		resultGrid.data.forEach { cell ->
+			assertFalse(
+				cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+				"No cells should be highlighted if the number is not present.",
+			)
+		}
+	}
+
+	@Test
+	fun `Grid state with all cells matching the number`() {
+		val allMatchData = listOf(
+			intArrayOf(7, 7, 7),
+			intArrayOf(7, 7, 7),
+			intArrayOf(7, 7, 7),
+		)
+		val initialGrid = SudokuGrid.fromIntArray(allMatchData, gridSize = 3)
+		val numberToHighlight = 7
+
+		val resultGrid = useCase(initialGrid, numberToHighlight)
+
+		resultGrid.data.forEach { cell ->
+			assertTrue(
+				cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+				"All cells matching the number $numberToHighlight should be highlighted.",
+			)
+		}
+	}
+
+	@Test
+	fun `Highlighting behavior based on SettingsRepository highlightMatching setting`() {
+		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
+		val numberToHighlight = 1
+
+		every { mockSettingsRepository.highlightMatchingNumbers } returns flowOf(false)
+		var resultGrid = useCase(initialGrid, numberToHighlight)
+
+		assertTrue(
+			resultGrid.getCellAt(0, 0).attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+			"Cell (0,0) should be highlighted even if (unused) setting is false, due to current use case logic.",
+		)
+
+		every { mockSettingsRepository.highlightMatchingNumbers } returns flowOf(true)
+		resultGrid = useCase(initialGrid, numberToHighlight)
+		assertTrue(
+			resultGrid.getCellAt(0, 0).attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+			"Cell (0,0) should be highlighted when (unused) setting is true.",
+		)
+
+		resultGrid = useCase(initialGrid, null)
+		assertFalse(
+			resultGrid.getCellAt(0, 0).attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+			"Cell (0,0) should not be highlighted when number is null, regardless of setting.",
+		)
+	}
+
+	@Test
+	fun `Input SudokuGrid immutability or expected mutation`() {
+		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
+		val initialGridDataSnapshot =
+			initialGrid.data.toList() // Save a deep copy of data for comparison
+
+		val resultGrid = useCase(initialGrid, 1)
+
+		assertNotSame(initialGrid, resultGrid, "UseCase should return a new SudokuGrid instance.")
+		assertEquals(
+			initialGridDataSnapshot.size,
+			initialGrid.data.size,
+			"Original grid size should not change.",
+		)
+		for (i in initialGridDataSnapshot.indices) {
+			assertEquals(
+				initialGridDataSnapshot[i],
+				initialGrid.data[i],
+				"Original grid cell data at index $i should remain unchanged.",
+			)
+		}
+		// Verify a specific cell in original grid didn't get highlights
+		assertFalse(
+			initialGrid.getCellAt(
+				0,
+				0,
+			).attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+			"Original grid cell (0,0) should not be modified.",
+		)
+	}
+
+	@Test
+	fun `Highlighting with number outside typical Sudoku range e g 9 or 1`() {
+		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
+
+		// Test with a number like 10 (not in grid)
+		var resultGrid = useCase(initialGrid, 10)
+		resultGrid.data.forEach { cell ->
+			assertFalse(
+				cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+				"No cells should be highlighted for number 10.",
+			)
+		}
+
+		// Test with a negative number like -1 (not in grid)
+		resultGrid = useCase(initialGrid, -1)
+		resultGrid.data.forEach { cell ->
+			assertFalse(
+				cell.attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
+				"No cells should be highlighted for number -1.",
+			)
+		}
+	}
+}

--- a/domain/game/src/test/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCaseTest.kt
@@ -10,6 +10,7 @@ import io.mockk.impl.annotations.RelaxedMockK
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.plus
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotSame
@@ -48,7 +49,7 @@ class HighlightMatchingNumbersUseCaseTest {
 	}
 
 	@Test
-	fun `Highlighting matching numbers with valid number`() {
+	fun `Highlighting matching numbers with valid number`() = runTest {
 		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
 		val numberToHighlight = 1
 
@@ -70,7 +71,7 @@ class HighlightMatchingNumbersUseCaseTest {
 	}
 
 	@Test
-	fun `Highlighting with null number`() {
+	fun `Highlighting with null number`() = runTest {
 		val initialGridWithHighlights =
 			createGridWithHighlight(1) // Start with some cells highlighted
 		assertTrue(
@@ -90,7 +91,7 @@ class HighlightMatchingNumbersUseCaseTest {
 	}
 
 	@Test
-	fun `Highlighting with zero as number`() {
+	fun `Highlighting with zero as number`() = runTest {
 		val initialGridWithHighlights =
 			createGridWithHighlight(2) // Start with some cells highlighted
 		assertTrue(
@@ -110,7 +111,7 @@ class HighlightMatchingNumbersUseCaseTest {
 	}
 
 	@Test
-	fun `Grid state after clearing highlights`() {
+	fun `Grid state after clearing highlights`() = runTest {
 		// Create a grid with cell (0,0) value 1 and already highlighted
 		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
 			.updateCell(
@@ -137,7 +138,7 @@ class HighlightMatchingNumbersUseCaseTest {
 	}
 
 	@Test
-	fun `Grid state with no matching numbers`() {
+	fun `Grid state with no matching numbers`() = runTest {
 		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
 		val numberToHighlight = 5 // This number is not in sampleGridData
 
@@ -152,7 +153,7 @@ class HighlightMatchingNumbersUseCaseTest {
 	}
 
 	@Test
-	fun `Grid state with all cells matching the number`() {
+	fun `Grid state with all cells matching the number`() = runTest {
 		val allMatchData = listOf(
 			intArrayOf(7, 7, 7),
 			intArrayOf(7, 7, 7),
@@ -172,23 +173,23 @@ class HighlightMatchingNumbersUseCaseTest {
 	}
 
 	@Test
-	fun `Highlighting behavior based on SettingsRepository highlightMatching setting`() {
+	fun `Highlighting behavior based on SettingsRepository highlightMatching setting`() = runTest {
 		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
 		val numberToHighlight = 1
 
 		every { mockSettingsRepository.highlightMatchingNumbers } returns flowOf(false)
 		var resultGrid = useCase(initialGrid, numberToHighlight)
 
-		assertTrue(
+		assertFalse(
 			resultGrid.getCellAt(0, 0).attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
-			"Cell (0,0) should be highlighted even if (unused) setting is false, due to current use case logic.",
+			"Cell (0,0) should not be highlighted  if setting is false. ",
 		)
 
 		every { mockSettingsRepository.highlightMatchingNumbers } returns flowOf(true)
 		resultGrid = useCase(initialGrid, numberToHighlight)
 		assertTrue(
 			resultGrid.getCellAt(0, 0).attributes.contains(CellAttributes.NUMBER_MATCH_HIGHLIGHTED),
-			"Cell (0,0) should be highlighted when (unused) setting is true.",
+			"Cell (0,0) should be highlighted when setting is true.",
 		)
 
 		resultGrid = useCase(initialGrid, null)
@@ -199,7 +200,7 @@ class HighlightMatchingNumbersUseCaseTest {
 	}
 
 	@Test
-	fun `Input SudokuGrid immutability or expected mutation`() {
+	fun `Input SudokuGrid immutability or expected mutation`() = runTest {
 		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
 		val initialGridDataSnapshot =
 			initialGrid.data.toList() // Save a deep copy of data for comparison
@@ -230,7 +231,7 @@ class HighlightMatchingNumbersUseCaseTest {
 	}
 
 	@Test
-	fun `Highlighting with number outside typical Sudoku range e g 9 or 1`() {
+	fun `Highlighting with number outside typical Sudoku range e g 9 or 1`() = runTest {
 		val initialGrid = SudokuGrid.fromIntArray(sampleGridData, gridSize = 4)
 
 		// Test with a number like 10 (not in grid)

--- a/domain/game/src/test/java/com/example/domain/game/usecases/RedoOperationUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/RedoOperationUseCaseTest.kt
@@ -14,7 +14,6 @@ import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.spyk
-import io.mockk.verify
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -53,7 +52,7 @@ class RedoOperationUseCaseTest {
 		coJustRun { operationRepository.addUndoOperation(any()) }
 		coEvery { operationRepository.findRedoOperation(any()) } returns mockk { every { id } returns 1L }
 		coJustRun { operationRepository.removeRedoOperation(any()) }
-		every { highlightMatchingNumbersUseCase(any(), any()) } returns updatedGrid
+		coEvery { highlightMatchingNumbersUseCase(any(), any()) } returns updatedGrid
 		coEvery {
 			inputNumberUseCase.invoke(
 				sudokuGrid = any(),
@@ -326,6 +325,6 @@ class RedoOperationUseCaseTest {
 		coEvery { operationRepository.getRedoOperations() } returns listOf(lastOperation)
 		redoOperationUseCase(initialGrid)
 
-		verify(exactly = 1) { highlightMatchingNumbersUseCase(any(), 0) }
+		coVerify(exactly = 1) { highlightMatchingNumbersUseCase(any(), 0) }
 	}
 }

--- a/domain/game/src/test/java/com/example/domain/game/usecases/SelectCellUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/SelectCellUseCaseTest.kt
@@ -3,11 +3,15 @@ package com.example.domain.game.usecases
 import com.example.sudoku.model.CellAttributes
 import com.example.sudoku.model.SudokuGrid
 import com.example.sudoku.model.addAttribute
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -25,7 +29,7 @@ class SelectCellUseCaseTest {
 			every { this@mockk.invoke(any(), any(), any()) } answers { firstArg() }
 		}
 		highlightMatchingNumbersUseCase = mockk(relaxed = true) {
-			every { this@mockk.invoke(any(), any()) } answers { firstArg() }
+			coEvery { this@mockk.invoke(any(), any()) } answers { firstArg() }
 		}
 		clearHighlightedRowAndColumnUseCase = mockk(relaxed = true) {
 			every { this@mockk.invoke(any()) } answers { firstArg() }
@@ -40,7 +44,7 @@ class SelectCellUseCaseTest {
 	}
 
 	@Test
-	fun `SelectCellUseCase selectedCell is null`() {
+	fun `SelectCellUseCase selectedCell is null`() = runTest {
 		// Verify that when selectedCell is null, the SudokuGrid is returned with previously selected cells deselected and highlights cleared.
 		val initialGrid =
 			emptyGrid.withReplacedCell(
@@ -55,11 +59,11 @@ class SelectCellUseCaseTest {
 		assert(!resultGrid.getCellAt(0, 0).attributes.contains(CellAttributes.SELECTED))
 		verify { clearHighlightedRowAndColumnUseCase(any()) }
 		verify(exactly = 0) { highlightRowAndColumnUseCase(any(), any(), any()) }
-		verify(exactly = 1) { highlightMatchingNumbersUseCase(any(), any()) }
+		coVerify(exactly = 1) { highlightMatchingNumbersUseCase(any(), any()) }
 	}
 
 	@Test
-	fun `SelectCellUseCase selectedCell is not null  cell has no initial attributes`() {
+	fun `SelectCellUseCase selectedCell is not null  cell has no initial attributes`() = runTest {
 		// Verify that when a valid cell is selected, it's marked as SELECTED, and row, column, and matching numbers are highlighted.
 		// The selected cell initially has no attributes.
 		val selectedCell = 1 to 2
@@ -75,7 +79,7 @@ class SelectCellUseCaseTest {
 	}
 
 	@Test
-	fun `SelectCellUseCase selectedCell is not null  cell has other attributes`() {
+	fun `SelectCellUseCase selectedCell is not null  cell has other attributes`() = runTest {
 		// Verify that when a valid cell with pre-existing attributes is selected, the SELECTED attribute is added without removing existing ones,
 		// and row, column, and matching numbers are highlighted.
 		val selectedCell = 1 to 2
@@ -103,7 +107,7 @@ class SelectCellUseCaseTest {
 	}
 
 	@Test
-	fun `SelectCellUseCase selecting a new cell when another cell is already selected`() {
+	fun `SelectCellUseCase selecting a new cell when another cell is already selected`() = runTest {
 		// Verify that if a cell is already selected, selecting a new cell correctly deselects the old one, clears its highlights,
 		// and selects and highlights the new cell and its related elements.
 		val oldSelectedCell = 0 to 0
@@ -141,7 +145,7 @@ class SelectCellUseCaseTest {
 	}
 
 	@Test
-	fun `SelectCellUseCase selected cell has a number`() {
+	fun `SelectCellUseCase selected cell has a number`() = runTest {
 		// Verify that highlightMatchingNumbersUseCase is called with the correct number from the selected cell.
 		val selectedCell = 3 to 4
 		val number = 5
@@ -149,11 +153,11 @@ class SelectCellUseCaseTest {
 
 		selectCellUseCase(initialGrid, selectedCell)
 
-		verify { highlightMatchingNumbersUseCase(any(), number) }
+		coVerify { highlightMatchingNumbersUseCase(any(), number) }
 	}
 
 	@Test
-	fun `SelectCellUseCase selected cell is empty  number is null or 0 `() {
+	fun `SelectCellUseCase selected cell is empty  number is null or 0 `() = runTest {
 		// Verify that highlightMatchingNumbersUseCase is called with null or 0 if the selected cell is empty, and handles it gracefully (no numbers highlighted).
 		val selectedCell = 2 to 2
 		val cell = emptyGrid.getCellAt(selectedCell.first, selectedCell.second)
@@ -161,11 +165,11 @@ class SelectCellUseCaseTest {
 
 		selectCellUseCase(emptyGrid, selectedCell)
 
-		verify(exactly = 0) { highlightMatchingNumbersUseCase(any(), any()) }
+		coVerify(exactly = 0) { highlightMatchingNumbersUseCase(any(), any()) }
 	}
 
 	@Test
-	fun `SelectCellUseCase SudokuGrid has pre existing selected cells`() {
+	fun `SelectCellUseCase SudokuGrid has pre existing selected cells`() = runTest {
 		// Verify that any cells in the input SudokuGrid that are already marked with CellAttributes.SELECTED are correctly deselected before processing the new selectedCell.
 		val preSelectedCell = 4 to 4
 		val newSelectedCell = 5 to 5
@@ -196,7 +200,7 @@ class SelectCellUseCaseTest {
 	}
 
 	@Test
-	fun `SelectCellUseCase interaction with highlightRowAndColumnUseCase`() {
+	fun `SelectCellUseCase interaction with highlightRowAndColumnUseCase`() = runTest {
 		// Ensure highlightRowAndColumnUseCase is called with the correct SudokuGrid (after deselection and clearing) and the correct row/column from selectedCell.
 		val selectedCell = 2 to 3
 		selectCellUseCase(emptyGrid, selectedCell)
@@ -208,7 +212,7 @@ class SelectCellUseCaseTest {
 	}
 
 	@Test
-	fun `SelectCellUseCase interaction with highlightMatchingNumbersUseCase`() {
+	fun `SelectCellUseCase interaction with highlightMatchingNumbersUseCase`() = runTest {
 		// Ensure highlightMatchingNumbersUseCase is called with the correct SudokuGrid (after selection and row/column highlighting) and the correct number from the selected cell.
 		val selectedCell = 2 to 3
 		val number = 7
@@ -216,14 +220,14 @@ class SelectCellUseCaseTest {
 
 		selectCellUseCase(initialGrid, selectedCell)
 
-		verifyOrder {
+		coVerifyOrder {
 			highlightRowAndColumnUseCase(any(), selectedCell.first, selectedCell.second)
 			highlightMatchingNumbersUseCase(any(), number)
 		}
 	}
 
 	@Test
-	fun `SelectCellUseCase immutability of input SudokuGrid`() {
+	fun `SelectCellUseCase immutability of input SudokuGrid`() = runTest {
 		// Confirm that the original sudoku object passed to the invoke method is not mutated, and a new instance is returned.
 		val initialGrid = emptyGrid.withValue(0, 0, 5)
 		val initialGridCopy = initialGrid.copy()
@@ -235,7 +239,7 @@ class SelectCellUseCaseTest {
 	}
 
 	@Test
-	fun `selecting an empty cell should not clear existing number highlights`() {
+	fun `selecting an empty cell should not clear existing number highlights`() = runTest {
 		// 1. Setup a grid with some highlighted numbers
 		val gridWithHighlights =
 			emptyGrid.addAttribute({ it.row == 0 }, CellAttributes.NUMBER_MATCH_HIGHLIGHTED)
@@ -252,11 +256,11 @@ class SelectCellUseCaseTest {
 		selectCellUseCase(gridWithHighlights, emptyCellToSelect)
 
 		// 3. Verify that clearHighlightedNumbersUseCase was NOT called
-		verify(exactly = 0) { highlightMatchingNumbersUseCase(any(), null) }
+		coVerify(exactly = 0) { highlightMatchingNumbersUseCase(any(), null) }
 	}
 
 	@Test
-	fun `SelectCellUseCase with an empty SudokuGrid  all cells empty `() {
+	fun `SelectCellUseCase with an empty SudokuGrid  all cells empty `() = runTest {
 		// Test behavior when a cell is selected in an entirely empty Sudoku grid.
 		val selectedCell = 0 to 0
 		val resultGrid = selectCellUseCase(emptyGrid, selectedCell)
@@ -269,11 +273,11 @@ class SelectCellUseCaseTest {
 		)
 
 		verify { highlightRowAndColumnUseCase(any(), selectedCell.first, selectedCell.second) }
-		verify(exactly = 0) { highlightMatchingNumbersUseCase(any(), any()) }
+		coVerify(exactly = 0) { highlightMatchingNumbersUseCase(any(), any()) }
 	}
 
 	@Test
-	fun `SelectCellUseCase with a fully solved SudokuGrid`() {
+	fun `SelectCellUseCase with a fully solved SudokuGrid`() = runTest {
 		// Test behavior when a cell is selected in a fully solved Sudoku grid, ensuring highlights work as expected.
 		// Create a simple solved grid
 		var solvedGrid: SudokuGrid = emptyGrid
@@ -293,6 +297,6 @@ class SelectCellUseCaseTest {
 		)
 
 		verify { highlightRowAndColumnUseCase(any(), selectedCell.first, selectedCell.second) }
-		verify { highlightMatchingNumbersUseCase(any(), selectedNumber) }
+		coVerify { highlightMatchingNumbersUseCase(any(), selectedNumber) }
 	}
 }

--- a/domain/game/src/test/java/com/example/domain/game/usecases/UndoOperationUseCaseTest.kt
+++ b/domain/game/src/test/java/com/example/domain/game/usecases/UndoOperationUseCaseTest.kt
@@ -14,7 +14,6 @@ import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.spyk
-import io.mockk.verify
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -442,7 +441,7 @@ class UndoOperationUseCaseTest {
 
 		undoOperationUseCase(initialGrid)
 
-		verify(exactly = 1) {
+		coVerify(exactly = 1) {
 			highlightMatchingNumbersUseCase(any(), 0)
 		}
 	}

--- a/domain/settings/src/main/java/com/example/domain/settings/SettingsRepository.kt
+++ b/domain/settings/src/main/java/com/example/domain/settings/SettingsRepository.kt
@@ -13,6 +13,7 @@ interface SettingsRepository {
 	val showActionButtonsOnTop: Flow<Boolean>
 	val insightsSummaryCompactLayout: Flow<Boolean>
 	val autoClearNotes: Flow<Boolean>
+	val highlightMatchingNumbers: Flow<Boolean>
 
 	suspend fun setDarkMode(darkMode: DarkMode)
 
@@ -29,6 +30,8 @@ interface SettingsRepository {
 	suspend fun setInsightsSummaryCompactLayout(compactLayout: Boolean)
 
 	suspend fun setAutoClearNotes(autoClearNotes: Boolean)
+
+	suspend fun setHighlightMatchingNumbers(highlightMatchingNumbers: Boolean)
 
 	fun getAvailableColorSchemes(): List<ColorScheme>
 

--- a/feature/settings/src/main/java/com/example/feature/settings/Module.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/Module.kt
@@ -4,5 +4,5 @@ import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
 val settingsModule = module {
-	viewModel { SettingsViewModel(get(), get()) }
+	viewModel { SettingsViewModel(get()) }
 }

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsScreen.kt
@@ -98,14 +98,14 @@ private fun SettingsScreenContent(
 			SettingsCategory("Appearance") {
 				SettingDropDownMenu(
 					title = "Theme",
-					description = if (uiState.appearence.darkMode == DarkMode.SYSTEM) {
+					description = if (uiState.appearance.darkMode == DarkMode.SYSTEM) {
 						"Follow system theme"
 					} else {
 						null
 					},
 					isExpanded = themeExpanded,
 					onExpandedChange = { themeExpanded = it },
-					selectedValue = uiState.appearence.darkMode,
+					selectedValue = uiState.appearance.darkMode,
 					onSelect = {
 						onEvent(SettingsViewModel.Event.SetDarkMode(it))
 					},
@@ -119,7 +119,7 @@ private fun SettingsScreenContent(
 					isExpanded = lightColorSchemeExpanded,
 					onExpandedChange = { lightColorSchemeExpanded = it },
 					onSelect = { onEvent(SettingsViewModel.Event.SetLightColorScheme(it)) },
-					selectedValue = uiState.appearence.lightColorScheme,
+					selectedValue = uiState.appearance.lightColorScheme,
 					options = lightColorSchemes,
 					optionToString = {
 						it.name
@@ -131,7 +131,7 @@ private fun SettingsScreenContent(
 					title = "Dark color scheme",
 					isExpanded = darkColorSchemeExpanded,
 					onExpandedChange = { darkColorSchemeExpanded = it },
-					selectedValue = uiState.appearence.darkColorScheme,
+					selectedValue = uiState.appearance.darkColorScheme,
 					onSelect = { onEvent(SettingsViewModel.Event.SetDarkColorScheme(it)) },
 					options = darkColorSchemes,
 					optionToString = {
@@ -142,7 +142,7 @@ private fun SettingsScreenContent(
 
 				SettingSwitchItem(
 					title = "Compact Insights summaries",
-					value = uiState.appearence.insightsSummaryCompactLayout,
+					value = uiState.appearance.insightsSummaryCompactLayout,
 					onValueChange = {
 						onEvent(SettingsViewModel.Event.ToggleInsightsSummaryCompactLayout(it))
 					},

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.domain.settings.models.ColorScheme
@@ -31,6 +32,7 @@ import com.example.feature.settings.components.SettingSwitchItem
 import com.example.feature.settings.components.SettingsCategory
 import com.example.feature.uicore.theme.LocalPadding
 import com.example.feature.uicore.theme.SudokuSlayerTheme
+import com.example.sudokuslayer.feature.settings.R
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.toPersistentSet
 import org.koin.androidx.compose.koinViewModel
@@ -96,14 +98,14 @@ private fun SettingsScreenContent(
 			SettingsCategory("Appearance") {
 				SettingDropDownMenu(
 					title = "Theme",
-					description = if (uiState.darkMode == DarkMode.SYSTEM) {
+					description = if (uiState.appearence.darkMode == DarkMode.SYSTEM) {
 						"Follow system theme"
 					} else {
 						null
 					},
 					isExpanded = themeExpanded,
 					onExpandedChange = { themeExpanded = it },
-					selectedValue = uiState.darkMode,
+					selectedValue = uiState.appearence.darkMode,
 					onSelect = {
 						onEvent(SettingsViewModel.Event.SetDarkMode(it))
 					},
@@ -117,7 +119,7 @@ private fun SettingsScreenContent(
 					isExpanded = lightColorSchemeExpanded,
 					onExpandedChange = { lightColorSchemeExpanded = it },
 					onSelect = { onEvent(SettingsViewModel.Event.SetLightColorScheme(it)) },
-					selectedValue = uiState.lightColorScheme,
+					selectedValue = uiState.appearence.lightColorScheme,
 					options = lightColorSchemes,
 					optionToString = {
 						it.name
@@ -129,7 +131,7 @@ private fun SettingsScreenContent(
 					title = "Dark color scheme",
 					isExpanded = darkColorSchemeExpanded,
 					onExpandedChange = { darkColorSchemeExpanded = it },
-					selectedValue = uiState.darkColorScheme,
+					selectedValue = uiState.appearence.darkColorScheme,
 					onSelect = { onEvent(SettingsViewModel.Event.SetDarkColorScheme(it)) },
 					options = darkColorSchemes,
 					optionToString = {
@@ -140,7 +142,7 @@ private fun SettingsScreenContent(
 
 				SettingSwitchItem(
 					title = "Compact Insights summaries",
-					value = uiState.insightsSummaryCompactLayout,
+					value = uiState.appearence.insightsSummaryCompactLayout,
 					onValueChange = {
 						onEvent(SettingsViewModel.Event.ToggleInsightsSummaryCompactLayout(it))
 					},
@@ -152,7 +154,7 @@ private fun SettingsScreenContent(
 				SettingSwitchItem(
 					title = "Left hand mode",
 					description = "Swap the layout of the keypad",
-					value = uiState.leftHandMode,
+					value = uiState.accessibility.leftHandMode,
 					onValueChange = { onEvent(SettingsViewModel.Event.ToggleLeftHandMode(it)) },
 					modifier = Modifier.fillMaxWidth(),
 				)
@@ -160,7 +162,7 @@ private fun SettingsScreenContent(
 				SettingSwitchItem(
 					title = "Show action buttons on top",
 					description = "Move the action buttons to the top of the screen",
-					value = uiState.actionButtonsOnTop,
+					value = uiState.accessibility.actionButtonsOnTop,
 					onValueChange = { onEvent(SettingsViewModel.Event.ToggleActionButtonsOnTop(it)) },
 					modifier = Modifier.fillMaxWidth(),
 				)
@@ -169,9 +171,16 @@ private fun SettingsScreenContent(
 			SettingsCategory("Gameplay") {
 				SettingSwitchItem(
 					title = "Auto clear notes",
-					value = uiState.autoClearNotes,
+					value = uiState.gameplay.autoClearNotes,
 					description = "Clear notes when a number is input",
 					onValueChange = { onEvent(SettingsViewModel.Event.ToggleAutoClearNotes(it)) },
+					modifier = Modifier.fillMaxWidth(),
+				)
+				SettingSwitchItem(
+					title = stringResource(R.string.gameplay_highlight_matching),
+					value = uiState.gameplay.highlightMatching,
+					description = stringResource(R.string.gameplay_highlight_matching_desc),
+					onValueChange = { onEvent(SettingsViewModel.Event.ToggleHighlightMatching(it)) },
 					modifier = Modifier.fillMaxWidth(),
 				)
 			}

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
@@ -1,6 +1,5 @@
 package com.example.feature.settings
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.domain.settings.SettingsRepository
@@ -37,10 +36,8 @@ internal data class GameplaySettings(
 	val highlightMatching: Boolean = true,
 )
 
-internal class SettingsViewModel(
-	private val settingsRepository: SettingsRepository,
-	private val savedStateHandle: SavedStateHandle,
-) : ViewModel() {
+internal class SettingsViewModel(private val settingsRepository: SettingsRepository) :
+	ViewModel() {
 	val lightColorSchemes = settingsRepository.getLightColorSchemes().toPersistentSet()
 	val darkColorSchemes = settingsRepository.getDarkColorSchemes().toPersistentSet()
 
@@ -98,7 +95,7 @@ internal class SettingsViewModel(
 		gameplayState,
 	) { appearence, accessibility, gameplay ->
 		SettingsUiState(
-			appearence = appearence,
+			appearance = appearence,
 			accessibility = accessibility,
 			gameplay = gameplay,
 		)

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 internal data class SettingsUiState(
-	val appearence: AppearanceSettings = AppearanceSettings(),
+	val appearance: AppearanceSettings = AppearanceSettings(),
 	val accessibility: AccessibilitySettings = AccessibilitySettings(),
 	val gameplay: GameplaySettings = GameplaySettings(),
 )

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
@@ -3,62 +3,104 @@ package com.example.feature.settings
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.core.combine
 import com.example.domain.settings.SettingsRepository
 import com.example.domain.settings.models.ColorScheme
 import com.example.domain.settings.models.DarkMode
 import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-data class SettingsUiState(
+internal data class SettingsUiState(
+	val appearence: AppearanceSettings = AppearanceSettings(),
+	val accessibility: AccessibilitySettings = AccessibilitySettings(),
+	val gameplay: GameplaySettings = GameplaySettings(),
+)
+
+internal data class AppearanceSettings(
 	val darkMode: DarkMode = DarkMode.SYSTEM,
 	val darkColorScheme: ColorScheme = ColorScheme.fromName("mocha"),
 	val lightColorScheme: ColorScheme = ColorScheme.fromName("latte"),
-	val language: String = "system",
-	val leftHandMode: Boolean = false,
-	val actionButtonsOnTop: Boolean = false,
 	val insightsSummaryCompactLayout: Boolean = true,
-	val autoClearNotes: Boolean = true,
+	val language: String = "system",
 )
 
-class SettingsViewModel(
+internal data class AccessibilitySettings(
+	val leftHandMode: Boolean = false,
+	val actionButtonsOnTop: Boolean = false,
+)
+
+internal data class GameplaySettings(
+	val autoClearNotes: Boolean = true,
+	val highlightMatching: Boolean = true,
+)
+
+internal class SettingsViewModel(
 	private val settingsRepository: SettingsRepository,
 	private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 	val lightColorSchemes = settingsRepository.getLightColorSchemes().toPersistentSet()
 	val darkColorSchemes = settingsRepository.getDarkColorSchemes().toPersistentSet()
 
-	val uiState: StateFlow<SettingsUiState> = combine(
+	private val appearenceState: StateFlow<AppearanceSettings> = combine(
 		settingsRepository.darkMode,
 		settingsRepository.darkModeColorScheme,
 		settingsRepository.lightModeColorScheme,
 		settingsRepository.language,
-		settingsRepository.leftHandMode,
-		settingsRepository.showActionButtonsOnTop,
 		settingsRepository.insightsSummaryCompactLayout,
-		settingsRepository.autoClearNotes,
-	) {
-			darkMode,
-			darkColorScheme,
-			lightColorScheme,
-			language,
-			leftHandMode,
-			actionButtonsOnTop,
-			insightsSummaryCompactLayout,
-			autoClearNotes,
-		->
-		SettingsUiState(
+	) { darkMode, darkColorScheme, lightColorScheme, language, insightsSummaryCompactLayout ->
+		AppearanceSettings(
 			darkMode = darkMode,
 			darkColorScheme = darkColorScheme,
 			lightColorScheme = lightColorScheme,
 			language = language,
+			insightsSummaryCompactLayout = insightsSummaryCompactLayout,
+		)
+	}.stateIn(
+		scope = viewModelScope,
+		started = SharingStarted.WhileSubscribed(5000L),
+		initialValue = AppearanceSettings(),
+	)
+
+	private val accessibilityState: StateFlow<AccessibilitySettings> = combine(
+		settingsRepository.leftHandMode,
+		settingsRepository.showActionButtonsOnTop,
+	) { leftHandMode, actionButtonsOnTop ->
+		AccessibilitySettings(
 			leftHandMode = leftHandMode,
 			actionButtonsOnTop = actionButtonsOnTop,
-			insightsSummaryCompactLayout = insightsSummaryCompactLayout,
+		)
+	}.stateIn(
+		scope = viewModelScope,
+		started = SharingStarted.WhileSubscribed(5000L),
+		initialValue = AccessibilitySettings(),
+	)
+
+	private val gameplayState: StateFlow<GameplaySettings> = combine(
+		settingsRepository.autoClearNotes,
+		settingsRepository.highlightMatchingNumbers,
+	) { autoClearNotes, highlightMatching ->
+		GameplaySettings(
 			autoClearNotes = autoClearNotes,
+			highlightMatching = highlightMatching,
+		)
+	}.stateIn(
+		scope = viewModelScope,
+		started = SharingStarted.WhileSubscribed(5000L),
+		initialValue = GameplaySettings(),
+	)
+
+	val uiState: StateFlow<SettingsUiState> = combine(
+		appearenceState,
+		accessibilityState,
+		gameplayState,
+	) { appearence, accessibility, gameplay ->
+		SettingsUiState(
+			appearence = appearence,
+			accessibility = accessibility,
+			gameplay = gameplay,
 		)
 	}.stateIn(
 		scope = viewModelScope,
@@ -80,8 +122,8 @@ class SettingsViewModel(
 		data class ToggleActionButtonsOnTop(val actionButtonsOnTop: Boolean) : Event
 
 		data class ToggleInsightsSummaryCompactLayout(val compactLayout: Boolean) : Event
-
 		data class ToggleAutoClearNotes(val autoClearNotes: Boolean) : Event
+		data class ToggleHighlightMatching(val highlightMatching: Boolean) : Event
 	}
 
 	fun onEvent(event: Event) {
@@ -97,6 +139,7 @@ class SettingsViewModel(
 			)
 
 			is Event.ToggleAutoClearNotes -> toggleAutoClearNotes(event.autoClearNotes)
+			is Event.ToggleHighlightMatching -> toggleHighlightMatching(event.highlightMatching)
 		}
 	}
 
@@ -145,6 +188,12 @@ class SettingsViewModel(
 	private fun toggleAutoClearNotes(autoClearNotes: Boolean) {
 		viewModelScope.launch {
 			settingsRepository.setAutoClearNotes(autoClearNotes)
+		}
+	}
+
+	private fun toggleHighlightMatching(highlightMatching: Boolean) {
+		viewModelScope.launch {
+			settingsRepository.setHighlightMatchingNumbers(highlightMatching)
 		}
 	}
 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="settings_screen_title">Settings</string>
+    <string name="gameplay_highlight_matching_desc">When a cell with a number is selected, all other cells with the same number will be highlighted.</string>
+	<string name="gameplay_highlight_matching">Highlight Matching Numbers</string>
 </resources>


### PR DESCRIPTION
This pull request introduces a new feature to toggle highlight of matching numbers in a Sudoku grid, along with test updates. The most important changes include adding a new setting for highlighting matching numbers, modifying the `HighlightMatchingNumbersUseCase` to respect this setting, and ensuring proper test coverage for the new functionality.

### Feature Implementation:

* **Settings Integration**:
  - Added a new preference key `HighlightMatchingNumbers` to `SettingsPreferenceKeys` with a default value of `true`. (`data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.kt`, [data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.ktR41-R45](diffhunk://#diff-ce8d272fd3a3413aa4c6d4c19a591004cfa9cca3305033c189b6d3018c9cf430R41-R45))
  - Updated `AndroidSettingsRepository` to include `highlightMatchingNumbers` as a new flow and added a setter method for it. (`data/settings/src/main/java/com/example/data/settings/AndroidSettingsRepository.kt`, [[1]](diffhunk://#diff-c9523922259fc2d4e847df28b37bf1582833548cc0ae8bba5a48d879da67685bR52-R55) [[2]](diffhunk://#diff-c9523922259fc2d4e847df28b37bf1582833548cc0ae8bba5a48d879da67685bR88-R94)

* **Use Case Enhancement**:
  - Modified `HighlightMatchingNumbersUseCase` to depend on `SettingsRepository` and respect the `highlightMatchingNumbers` setting. The use case now checks the setting before applying highlights. (`domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.kt`, [domain/game/src/main/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCase.ktR3-R13](diffhunk://#diff-c29f8df5546261137ba331e98dd5876fd9fdfcc3755a73a44b3bfa3ef7494932R3-R13))

### Dependency and Test Updates:

* **Dependency Updates**:
  - Added `domain.settings` as a dependency in the `domain/game` module. (`domain/game/build.gradle.kts`, [domain/game/build.gradle.ktsL8-R9](diffhunk://#diff-28ffce5cce5437f886c297c05010e91eef0a6a80e372b7084bc9db58d924ae67L8-R9))
  - Updated the `HighlightMatchingNumbersUseCase` factory to inject the `SettingsRepository`. (`domain/game/src/main/java/com/example/domain/game/Module.kt`, [domain/game/src/main/java/com/example/domain/game/Module.ktL44-R44](diffhunk://#diff-f97d44336ce3b1437b67b2083ec01f7f3e7de6bc261111998399739097995ac6L44-R44))

* **Test Coverage**:
  - Added extensive tests for `HighlightMatchingNumbersUseCase`, covering various scenarios such as valid/invalid numbers, settings behavior, and grid immutability. (`domain/game/src/test/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCaseTest.kt`, [domain/game/src/test/java/com/example/domain/game/usecases/HighlightMatchingNumbersUseCaseTest.ktR1-R255](diffhunk://#diff-b9b0e93651c91101af7da49515839fa66b9390886d3b98bd2818ad0f0b7b9710R1-R255))
  - Updated tests for `SelectCellUseCase` and `RedoOperationUseCase` to handle the now-suspendable `HighlightMatchingNumbersUseCase`. (`domain/game/src/test/java/com/example/domain/game/usecases/SelectCellUseCaseTest.kt`, [[1]](diffhunk://#diff-552b09d88278fadb3306e0c0dddaec0301fb96975a859cdd7bfa72d5a12d30a0L28-R32); `domain/game/src/test/java/com/example/domain/game/usecases/RedoOperationUseCaseTest.kt`, [[2]](diffhunk://#diff-a86ea5e14c0f9ca7ef146b43036e0162b21c4ef2a10a21617ce35923cb4d8325L56-R55)

These changes collectively enhance the user experience by introducing a customizable feature for highlighting matching numbers in Sudoku grids while maintaining robust test coverage.