### PR TITLE
Feat/toggle timer visibility

### DIFF
--- a/data/settings/src/main/java/com/example/data/settings/AndroidSettingsRepository.kt
+++ b/data/settings/src/main/java/com/example/data/settings/AndroidSettingsRepository.kt
@@ -57,6 +57,10 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 		SettingsPreferenceKeys.HighlightInvalidNumbers,
 	).map { it == true }
 
+	override val timerVisibility: Flow<Boolean> = preferenceStorage.getAsFlow(
+		SettingsPreferenceKeys.TimerVisibility,
+	).map { it == true }
+
 	override suspend fun setDarkMode(darkMode: DarkMode) {
 		preferenceStorage.set(SettingsPreferenceKeys.DarkMode, darkMode.displayName)
 	}
@@ -100,6 +104,13 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 		preferenceStorage.set(
 			SettingsPreferenceKeys.HighlightInvalidNumbers,
 			highlightInvalidNumbers,
+		)
+	}
+
+	override suspend fun setTimerVisibility(timerVisibility: Boolean) {
+		preferenceStorage.set(
+			SettingsPreferenceKeys.TimerVisibility,
+			timerVisibility,
 		)
 	}
 

--- a/data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.kt
+++ b/data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.kt
@@ -48,4 +48,9 @@ interface SettingsPreferenceKeys {
 		name = "highlight_invalid_numbers",
 		defaultValue = true,
 	)
+
+	data object TimerVisibility : PreferenceStorage.Key.BooleanKey(
+		name = "timer_visibility",
+		defaultValue = true,
+	)
 }

--- a/domain/settings/src/main/java/com/example/domain/settings/SettingsRepository.kt
+++ b/domain/settings/src/main/java/com/example/domain/settings/SettingsRepository.kt
@@ -15,6 +15,7 @@ interface SettingsRepository {
 	val autoClearNotes: Flow<Boolean>
 	val highlightMatchingNumbers: Flow<Boolean>
 	val highlightInvalidNumbers: Flow<Boolean>
+	val timerVisibility: Flow<Boolean>
 
 	suspend fun setDarkMode(darkMode: DarkMode)
 
@@ -35,6 +36,8 @@ interface SettingsRepository {
 	suspend fun setHighlightMatchingNumbers(highlightMatchingNumbers: Boolean)
 
 	suspend fun setHighlightInvalidNumbers(highlightInvalidNumbers: Boolean)
+
+	suspend fun setTimerVisibility(timerVisibility: Boolean)
 
 	fun getAvailableColorSchemes(): List<ColorScheme>
 

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
@@ -214,9 +214,11 @@ private fun SudokuGameScreenContent(
 			CenterAlignedTopAppBar(
 				windowInsets = WindowInsets.displayCutout,
 				title = {
-					TimerDisplay(
-						elapsedTime = elapsedTime(),
-					)
+					if (uiState.timerVisible) {
+						TimerDisplay(
+							elapsedTime = elapsedTime(),
+						)
+					}
 				},
 				colors =
 				TopAppBarDefaults.topAppBarColors(

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
@@ -88,6 +89,7 @@ internal class SudokuGameViewModel(
 		)
 
 	init {
+		observeSettings()
 		viewModelScope.launch {
 			_uiState.update {
 				it.copy(
@@ -107,24 +109,6 @@ internal class SudokuGameViewModel(
 			}
 			if (_uiState.value.gameState == GameState.PLAYING) {
 				elapsedTimerManager.startTracking()
-			}
-		}
-
-		viewModelScope.launch {
-			combine(
-				settingsRepository.leftHandMode,
-				settingsRepository.showActionButtonsOnTop,
-				settingsRepository.autoClearNotes,
-			) { leftHandMode, showActionButtonsOnTop, autoClearNotes ->
-				Triple(leftHandMode, showActionButtonsOnTop, autoClearNotes)
-			}.collect { (leftHandMode, showActionButtonsOnTop, autoClearNotes) ->
-				_uiState.update {
-					it.copy(
-						isLeftHandMode = leftHandMode,
-						showActionButtonsOnTop = showActionButtonsOnTop,
-						autoClearNotes = autoClearNotes,
-					)
-				}
 			}
 		}
 
@@ -216,6 +200,7 @@ internal class SudokuGameViewModel(
 			is Event.StopTimer -> {
 				stopTrackingTime()
 			}
+
 			is Event.StartTimer -> {
 				elapsedTimerManager.startTracking()
 			}
@@ -255,6 +240,26 @@ internal class SudokuGameViewModel(
 					)
 				}
 			}
+		}
+	}
+
+	private fun observeSettings() {
+		viewModelScope.launch {
+			combine(
+				settingsRepository.leftHandMode,
+				settingsRepository.showActionButtonsOnTop,
+				settingsRepository.autoClearNotes,
+				settingsRepository.timerVisibility,
+			) { leftHandMode, showActionButtonsOnTop, autoClearNotes, timerVisibility ->
+				_uiState.update {
+					it.copy(
+						isLeftHandMode = leftHandMode,
+						showActionButtonsOnTop = showActionButtonsOnTop,
+						autoClearNotes = autoClearNotes,
+						timerVisible = timerVisibility,
+					)
+				}
+			}.collect()
 		}
 	}
 
@@ -505,6 +510,7 @@ internal class SudokuGameViewModel(
 				is HintType.HiddenSingle, is HintType.NakedSingle -> {
 					listOf(Pair(hint.row, hint.col))
 				}
+
 				is HintType.ClaimingCandidate, is HintType.PointingCandidate -> {
 					hint.enforcingCells.map { it.row to it.col }
 				}

--- a/feature/game/src/main/java/com/example/feature/game/model/GameModels.kt
+++ b/feature/game/src/main/java/com/example/feature/game/model/GameModels.kt
@@ -15,6 +15,7 @@ internal data class SudokuGameUiState(
 	val currentBestTime: Long? = null,
 	val isNewBestTime: Boolean = false,
 	val autoClearNotes: Boolean = true,
+	val timerVisible: Boolean = true,
 )
 
 internal enum class GameState {

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsScreen.kt
@@ -171,6 +171,13 @@ private fun SettingsScreenContent(
 
 			SettingsCategory("Gameplay") {
 				SettingSwitchItem(
+					title = stringResource(R.string.gameplay_hide_in_game_timer),
+					value = !uiState.gameplay.timerVisibility,
+					description = stringResource(R.string.gameplay_hide_in_game_timer_desc),
+					onValueChange = { onEvent(SettingsViewModel.Event.ToggleTimerVisibility(it)) },
+					modifier = Modifier.fillMaxWidth(),
+				)
+				SettingSwitchItem(
 					title = "Auto clear notes",
 					value = uiState.gameplay.autoClearNotes,
 					description = "Clear notes when a number is input",

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
@@ -35,6 +35,7 @@ internal data class GameplaySettings(
 	val autoClearNotes: Boolean = true,
 	val highlightMatching: Boolean = true,
 	val highlightInvalid: Boolean = true,
+	val timerVisibility: Boolean = true,
 )
 
 internal class SettingsViewModel(private val settingsRepository: SettingsRepository) :
@@ -80,11 +81,13 @@ internal class SettingsViewModel(private val settingsRepository: SettingsReposit
 		settingsRepository.autoClearNotes,
 		settingsRepository.highlightMatchingNumbers,
 		settingsRepository.highlightInvalidNumbers,
-	) { autoClearNotes, highlightMatching, highlightInvalid ->
+		settingsRepository.timerVisibility,
+	) { autoClearNotes, highlightMatching, highlightInvalid, timerVisibility ->
 		GameplaySettings(
 			autoClearNotes = autoClearNotes,
 			highlightMatching = highlightMatching,
 			highlightInvalid = highlightInvalid,
+			timerVisibility = timerVisibility,
 		)
 	}.stateIn(
 		scope = viewModelScope,
@@ -125,6 +128,7 @@ internal class SettingsViewModel(private val settingsRepository: SettingsReposit
 		data class ToggleAutoClearNotes(val autoClearNotes: Boolean) : Event
 		data class ToggleHighlightMatching(val highlightMatching: Boolean) : Event
 		data class ToggleHighlightInvalid(val highlightInvalid: Boolean) : Event
+		data class ToggleTimerVisibility(val timerVisibility: Boolean) : Event
 	}
 
 	fun onEvent(event: Event) {
@@ -142,6 +146,7 @@ internal class SettingsViewModel(private val settingsRepository: SettingsReposit
 			is Event.ToggleAutoClearNotes -> toggleAutoClearNotes(event.autoClearNotes)
 			is Event.ToggleHighlightMatching -> toggleHighlightMatching(event.highlightMatching)
 			is Event.ToggleHighlightInvalid -> toggleHighlightInvalid(event.highlightInvalid)
+			is Event.ToggleTimerVisibility -> toggleTimerVisibility(event.timerVisibility)
 		}
 	}
 
@@ -202,6 +207,13 @@ internal class SettingsViewModel(private val settingsRepository: SettingsReposit
 	private fun toggleHighlightInvalid(highlightInvalid: Boolean) {
 		viewModelScope.launch {
 			settingsRepository.setHighlightInvalidNumbers(highlightInvalid)
+		}
+	}
+
+	private fun toggleTimerVisibility(timerVisibility: Boolean) {
+		viewModelScope.launch {
+			// When timerVisibility is true (user wants to hide), we save visibility as false.
+			settingsRepository.setTimerVisibility(!timerVisibility)
 		}
 	}
 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
 	<string name="gameplay_highlight_matching">Highlight Matching Numbers</string>
 	<string name="gameplay_mark_invalid_desc">Automatically highlight numbers that break the rules of Sudoku (e.g., duplicates in a row, column, or block).</string>
 	<string name="gameplay_mark_invalid">Mark Invalid Numbers</string>
+	<string name="gameplay_hide_in_game_timer">Hide In-Game Timer</string>
+	<string name="gameplay_hide_in_game_timer_desc">Hides the timer during gameplay so you can solve at your own pace. Your final time is still recorded.</string>
 </resources>


### PR DESCRIPTION
This pull request introduces a new feature to toggle the visibility of the in-game timer, along with the necessary integration across the settings, game UI, and underlying data layers. Below is a summary of the most important changes grouped by theme:

### Feature Implementation: Timer Visibility Toggle

* **Data Layer Updates**:
  - Added a new key, `TimerVisibility`, to `SettingsPreferenceKeys` with a default value of `true`. (`data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.kt`)
  - Updated `AndroidSettingsRepository` to include `timerVisibility` as a `Flow<Boolean>` and added a method `setTimerVisibility` to modify this setting. (`data/settings/src/main/java/com/example/data/settings/AndroidSettingsRepository.kt`) [[1]](diffhunk://#diff-c9523922259fc2d4e847df28b37bf1582833548cc0ae8bba5a48d879da67685bR60-R63) [[2]](diffhunk://#diff-c9523922259fc2d4e847df28b37bf1582833548cc0ae8bba5a48d879da67685bR110-R116)

* **Domain Layer Updates**:
  - Extended the `SettingsRepository` interface to include `timerVisibility` and `setTimerVisibility`. (`domain/settings/src/main/java/com/example/domain/settings/SettingsRepository.kt`) [[1]](diffhunk://#diff-15e7703f8a985933c09f17129d6df65b8431d17d53c41c297e494daa0b476e2bR18) [[2]](diffhunk://#diff-15e7703f8a985933c09f17129d6df65b8431d17d53c41c297e494daa0b476e2bR40-R41)

* **Settings UI Integration**:
  - Added a new switch in the "Gameplay" section of the settings screen to toggle the timer visibility. (`feature/settings/src/main/java/com/example/feature/settings/SettingsScreen.kt`)
  - Updated `SettingsViewModel` to handle the new timer visibility setting, including observing its state and adding an event `ToggleTimerVisibility`. (`feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt`) [[1]](diffhunk://#diff-9a9872acf847434f1dc1d353a3ecdc5f3d9e44f5fa9f90a53610c6515cd3fd16R38) [[2]](diffhunk://#diff-9a9872acf847434f1dc1d353a3ecdc5f3d9e44f5fa9f90a53610c6515cd3fd16L83-R90) [[3]](diffhunk://#diff-9a9872acf847434f1dc1d353a3ecdc5f3d9e44f5fa9f90a53610c6515cd3fd16R131) [[4]](diffhunk://#diff-9a9872acf847434f1dc1d353a3ecdc5f3d9e44f5fa9f90a53610c6515cd3fd16R149) [[5]](diffhunk://#diff-9a9872acf847434f1dc1d353a3ecdc5f3d9e44f5fa9f90a53610c6515cd3fd16R212-R218)
  - Added corresponding string resources for the new setting. (`feature/settings/src/main/res/values/strings.xml`)

* **Game UI Integration**:
  - Updated the `SudokuGameScreen` to conditionally display the timer based on the `timerVisible` state. (`feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt`)
  - Added `timerVisible` to the `SudokuGameUiState` data class. (`feature/game/src/main/java/com/example/feature/game/model/GameModels.kt`)

* **Game ViewModel Updates**:
  - Refactored `SudokuGameViewModel` to observe the `timerVisibility` setting and update the UI state accordingly. (`feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt`) [[1]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R92) [[2]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R246-R265)

These changes ensure a seamless integration of the timer visibility toggle across the application, enhancing user customization options.