### PR TITLE
Fix: adjust opacity of clear action menu item based on enabled state

### DIFF
--- a/feature/statistics/src/main/java/com/example/feature/statistics/insights/InsightsScreen.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/insights/InsightsScreen.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.composables.core.Menu
 import com.composables.core.ScrollArea
 import com.composables.core.Thumb
 import com.composables.core.ThumbVisibility.HideWhileIdle

--- a/feature/statistics/src/main/java/com/example/feature/statistics/insights/components/TopAppBarActions.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/insights/components/TopAppBarActions.kt
@@ -90,7 +90,9 @@ internal fun TopAppBarActions(
 			MenuItem(
 				onClick = onClearClick,
 				enabled = clearActionEnabled,
-				modifier = Modifier.height(48.dp).alpha(0.38f),
+				modifier = Modifier
+					.height(48.dp)
+					.alpha(if (clearActionEnabled) 1f else 0.38f),
 			) {
 				Icon(
 					painter = painterResource(R.drawable.delete),


### PR DESCRIPTION
This pull request makes minor adjustments to the `InsightsScreen` and `TopAppBarActions` components in the `feature/statistics` module. The changes focus on cleaning up unused imports and improving UI behavior for a menu item.

### Code cleanup:
* Removed an unused import for `Menu` in `InsightsScreen.kt`, which simplifies the code and removes unnecessary dependencies.

### UI improvements:
* Updated the `modifier` for the `MenuItem` in `TopAppBarActions.kt` to dynamically adjust the `alpha` property based on the `clearActionEnabled` state, ensuring better visual feedback for users.