### PR TITLE
Fix: prevent hint focus blinking by managing coroutine jobs

### DIFF
--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -29,10 +29,12 @@ import com.example.sudoku.model.fillNotes
 import com.example.sudoku.solver.ClassicSudokuSolver
 import com.example.sudoku.solver.Hint
 import com.example.sudoku.solver.HintType
-import kotlinx.collections.immutable.minus
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.plus
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentSet
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -72,6 +74,7 @@ internal class SudokuGameViewModel(
 
 	private val _uiState = MutableStateFlow<SudokuGameUiState>(SudokuGameUiState())
 	val uiState: StateFlow<SudokuGameUiState> = _uiState
+	private var hintFocusJob: Job? = null
 
 	private val _game =
 		MutableStateFlow<Game>(
@@ -511,7 +514,8 @@ internal class SudokuGameViewModel(
 	}
 
 	private fun hintFocus(hint: Hint) {
-		viewModelScope.launch {
+		hintFocusJob?.cancel()
+		hintFocusJob = viewModelScope.launch {
 			if (_uiState.value.gameState == GameState.VICTORY) return@launch
 
 			val cellsToFocus = when (hint.type) {
@@ -528,7 +532,7 @@ internal class SudokuGameViewModel(
 
 			_uiState.update { state ->
 				state.copy(
-					focusedCells = state.focusedCells + cellsToFocus,
+					focusedCells = cellsToFocus.toPersistentSet(),
 				)
 			}
 
@@ -536,7 +540,7 @@ internal class SudokuGameViewModel(
 
 			_uiState.update { state ->
 				state.copy(
-					focusedCells = state.focusedCells - cellsToFocus,
+					focusedCells = persistentSetOf(),
 				)
 			}
 		}


### PR DESCRIPTION
This pull request refactors the `SudokuGameViewModel` to improve state management and introduce better handling of hint focus functionality. The key changes include replacing mutable collections with immutable persistent sets, adding a `Job` to manage hint focus operations, and ensuring proper cleanup of focused cells after a delay.

### State management improvements:

* Replaced the use of mutable collections with immutable `persistentSetOf` for `focusedCells`, ensuring better immutability and thread safety. (`feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt`, [feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.ktL531-R543](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L531-R543))
* Updated imports to include `persistentSetOf` and `toPersistentSet` to support the transition to immutable sets. (`feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt`, [feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.ktL32-R37](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L32-R37))

### Hint focus functionality:

* Introduced a `hintFocusJob` property to manage the lifecycle of the hint focus coroutine, ensuring active jobs are canceled before starting a new one. (`feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt`, [[1]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R77) [[2]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L514-R518)
* Modified the `hintFocus` method to clear `focusedCells` after the delay using `persistentSetOf()` instead of subtracting cells, simplifying the logic. (`feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt`, [feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.ktL531-R543](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L531-R543))