### PR TITLE
Feat: select cell after long click in Sudoku game

### DIFF
--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -587,6 +587,7 @@ internal class SudokuGameViewModel(
 
 			val cell = game.value.grid.getCellAt(row, column)
 			if (cell.cornerNotes.size == 1) {
+				selectCell(row, column)
 				inputNumber(
 					number = cell.cornerNotes.first(),
 					selectedCell = row to column,


### PR DESCRIPTION
This pull request includes a small change to the `SudokuGameViewModel` class. The change ensures that a cell is selected when it contains exactly one corner note before inputting a number.