### PR TITLE
Refactor/encapsulate game theming

### DIFF
--- a/app/src/main/java/com/example/sudokuslayer/AppContent.kt
+++ b/app/src/main/java/com/example/sudokuslayer/AppContent.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.WideNavigationRailValue
 import androidx.compose.material3.rememberWideNavigationRailState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -41,7 +40,6 @@ import com.example.feature.statistics.Insights
 import com.example.feature.statistics.insightsEntry
 import com.example.feature.uicore.components.SudokuNavigationRail
 import com.example.feature.uicore.navigation.Destination
-import com.example.feature.uicore.theme.LocalAppColorScheme
 import com.example.feature.uicore.theme.SudokuSlayerTheme
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
@@ -98,92 +96,90 @@ internal fun AppContent(viewModel: AppViewModel = koinViewModel()) {
 		lightColorScheme = lightColorScheme,
 	)
 
-	CompositionLocalProvider(LocalAppColorScheme provides currentColorScheme) {
-		SudokuSlayerTheme(
-			colorScheme = currentColorScheme,
-		) {
-			SudokuNavigationRail(
-				state = navigationRailState,
-				destinations = destinations,
-				hasActiveGame = hasActiveGame,
-				isSelected = { backstack.last() == it },
-				navigateToScreen = {
-					if (it == SudokuCreator) {
-						backstack.clear()
-						backstack.add(it)
-					} else if (backstack.last() != it) {
-						backstack.add(it)
-					}
-					scope.launch {
-						navigationRailState.collapse()
-					}
-				},
-				onCloseDrawer = { scope.launch { navigationRailState.collapse() } },
-			)
-			NavDisplay(
-				modifier = Modifier.fillMaxSize().background(
-					MaterialTheme.colorScheme.background,
-				),
-				backStack = backstack,
-				entryDecorators = listOf(
-					rememberSceneSetupNavEntryDecorator(),
-					rememberSavedStateNavEntryDecorator(),
-					rememberViewModelStoreNavEntryDecorator(),
-				),
-				entryProvider = entryProvider {
-					sudokuCreatorEntry(
-						navigateToGameScreen = {
-							scope.launch {
-								backstack.apply {
-									clear()
-									add(SudokuCreator)
-									add(SudokuGame)
-								}
+	SudokuSlayerTheme(
+		colorScheme = currentColorScheme,
+	) {
+		SudokuNavigationRail(
+			state = navigationRailState,
+			destinations = destinations,
+			hasActiveGame = hasActiveGame,
+			isSelected = { backstack.last() == it },
+			navigateToScreen = {
+				if (it == SudokuCreator) {
+					backstack.clear()
+					backstack.add(it)
+				} else if (backstack.last() != it) {
+					backstack.add(it)
+				}
+				scope.launch {
+					navigationRailState.collapse()
+				}
+			},
+			onCloseDrawer = { scope.launch { navigationRailState.collapse() } },
+		)
+		NavDisplay(
+			modifier = Modifier.fillMaxSize().background(
+				MaterialTheme.colorScheme.background,
+			),
+			backStack = backstack,
+			entryDecorators = listOf(
+				rememberSceneSetupNavEntryDecorator(),
+				rememberSavedStateNavEntryDecorator(),
+				rememberViewModelStoreNavEntryDecorator(),
+			),
+			entryProvider = entryProvider {
+				sudokuCreatorEntry(
+					navigateToGameScreen = {
+						scope.launch {
+							backstack.apply {
+								clear()
+								add(SudokuCreator)
+								add(SudokuGame)
 							}
-						},
-						openDrawer = {
-							scope.launch {
-								navigationRailState.expand()
+						}
+					},
+					openDrawer = {
+						scope.launch {
+							navigationRailState.expand()
+						}
+					},
+				)
+				gameEntry(
+					openDrawer = {
+						scope.launch {
+							navigationRailState.expand()
+						}
+					},
+					onPlayAgainClick = {
+						scope.launch {
+							backstack.removeLastOrNull()
+						}
+					},
+					onNavigateToInsightsClick = {
+						scope.launch {
+							backstack.apply {
+								removeLastOrNull()
+								add(Insights)
 							}
-						},
-					)
-					gameEntry(
-						openDrawer = {
-							scope.launch {
-								navigationRailState.expand()
-							}
-						},
-						onPlayAgainClick = {
-							scope.launch {
-								backstack.removeLastOrNull()
-							}
-						},
-						onNavigateToInsightsClick = {
-							scope.launch {
-								backstack.apply {
-									removeLastOrNull()
-									add(Insights)
-								}
-							}
-						},
-					)
-					insightsEntry(
-						openDrawer = {
-							scope.launch {
-								navigationRailState.expand()
-							}
-						},
-					)
-					settingsEntry(
-						openDrawer = {
-							scope.launch {
-								navigationRailState.expand()
-							}
-						},
-					)
-				},
-			)
-		}
+						}
+					},
+				)
+				insightsEntry(
+					openDrawer = {
+						scope.launch {
+							navigationRailState.expand()
+						}
+					},
+				)
+				settingsEntry(
+					openDrawer = {
+						scope.launch {
+							navigationRailState.expand()
+						}
+					},
+				)
+			},
+		)
 	}
 }
 

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -57,14 +56,7 @@ import com.example.feature.game.components.TimerDisplay
 import com.example.feature.game.components.VictoryDialog
 import com.example.feature.game.model.GameState
 import com.example.feature.game.model.SudokuGameUiState
-import com.example.feature.game.theme.LocalHintLogsColors
-import com.example.feature.game.theme.LocalKeyPadColors
-import com.example.feature.game.theme.LocalSudokuBoardColors
-import com.example.feature.game.theme.rememberBoardColors
-import com.example.feature.game.theme.rememberHintLogsColors
-import com.example.feature.game.theme.rememberKeypadColors
-import com.example.feature.uicore.theme.LocalAppColorScheme
-import com.example.feature.uicore.theme.SudokuSlayerTheme
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.sudoku.model.SudokuGrid
 import com.example.sudokuslayer.feature.game.R
 import kotlinx.collections.immutable.persistentListOf
@@ -85,16 +77,7 @@ internal fun SudokuGameScreen(
 	val uiState: SudokuGameUiState by viewModel.uiState.collectAsStateWithLifecycle()
 	val game by viewModel.game.collectAsStateWithLifecycle()
 
-	val colorScheme = LocalAppColorScheme.current
-	val boardColors = rememberBoardColors(colorScheme)
-	val keypadColors = rememberKeypadColors(colorScheme)
-	val hintLogsColors = rememberHintLogsColors(colorScheme)
-
-	CompositionLocalProvider(
-		LocalSudokuBoardColors provides boardColors,
-		LocalKeyPadColors provides keypadColors,
-		LocalHintLogsColors provides hintLogsColors,
-	) {
+	SudokuGameTheme(useSudokuSlayerTheme = false) {
 		LifecycleResumeEffect(Unit) {
 			viewModel.onEvent(Event.StartTimer)
 			onPauseOrDispose {
@@ -373,9 +356,10 @@ private fun SudokuGameScreenContent(
 @PreviewLightDark
 @Composable
 private fun SudokuGameScreenPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		SudokuGameScreenContent(
 			uiState = SudokuGameUiState(
+				selectedCell = 1 to 1,
 				gameState = GameState.VICTORY,
 			),
 			game =
@@ -399,7 +383,7 @@ private fun SudokuGameScreenPreview() {
 @Preview
 @Composable
 private fun SudokuGameScreenSixteenPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		SudokuGameScreenContent(
 			uiState = SudokuGameUiState(),
 			game =
@@ -425,9 +409,7 @@ private fun SudokuGameScreenSixteenPreview() {
 )
 @Composable
 private fun SudokuGameScreenFourPreview() {
-	SudokuSlayerTheme(
-		darkTheme = true,
-	) {
+	SudokuGameTheme {
 		SudokuGameScreenContent(
 			uiState =
 			SudokuGameUiState(

--- a/feature/game/src/main/java/com/example/feature/game/components/HintBottomSheetScaffold.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/HintBottomSheetScaffold.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.domain.core.HintLog
-import com.example.feature.uicore.theme.SudokuSlayerTheme
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.sudoku.solver.Hint
 import com.example.sudoku.solver.HintType
 import com.example.sudoku.solver.NakedSingleExplanation
@@ -218,7 +218,7 @@ internal fun BottomSheetElevatedButton(
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 private fun HintBottomSheetScaffoldPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		val scaffoldState =
 			rememberBottomSheetScaffoldState(
 				bottomSheetState =

--- a/feature/game/src/main/java/com/example/feature/game/components/HintStepCard.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/HintStepCard.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.feature.game.theme.LocalHintLogsColors
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.feature.uicore.theme.LocalPadding
-import com.example.feature.uicore.theme.SudokuSlayerTheme
 import com.example.feature.uicore.theme.extendedColorScheme
 import com.example.sudoku.solver.HintExplanationPart
 import com.example.sudoku.solver.HintExplanationStep
@@ -165,7 +165,7 @@ internal fun HintStepCard(
 @Composable
 internal fun HintStepCardPreview() {
 	val interactionSource = remember { MutableInteractionSource() }
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		Column(
 			verticalArrangement = Arrangement.spacedBy(12.dp),
 		) {

--- a/feature/game/src/main/java/com/example/feature/game/components/HintsDialog.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/HintsDialog.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import com.example.feature.uicore.theme.SudokuSlayerTheme
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.sudokuslayer.feature.game.R
 
 @Composable
@@ -123,7 +123,7 @@ private data class HintDialogButton(
 @PreviewLightDark
 @Composable
 private fun HintsDialogPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		HintsDialog(
 			isVisible = true,
 			onDismissRequest = { },

--- a/feature/game/src/main/java/com/example/feature/game/components/KeyPad.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/KeyPad.kt
@@ -30,10 +30,10 @@ import com.example.feature.game.components.keypadparts.InputModeSwitch
 import com.example.feature.game.components.keypadparts.KeyPadItem
 import com.example.feature.game.components.keypadparts.NumberPad
 import com.example.feature.game.theme.LocalKeyPadColors
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.feature.uicore.components.ReversibleRow
 import com.example.feature.uicore.navigation.AppIcon
 import com.example.feature.uicore.theme.LocalPadding
-import com.example.feature.uicore.theme.SudokuSlayerTheme
 import com.example.sudokuslayer.feature.game.R
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
@@ -251,7 +251,7 @@ private fun getMiddleActionPadItems(
 @PreviewLightDark
 @Composable
 private fun KeyPadPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		KeyPad(
 			onNumberClick = { },
 			onNumberLongClick = { },
@@ -273,7 +273,7 @@ private fun KeyPadPreview() {
 @Preview
 @Composable
 private fun KeyPadFourPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		KeyPad(
 			onNumberClick = { },
 			onNumberLongClick = { },
@@ -295,7 +295,7 @@ private fun KeyPadFourPreview() {
 @Preview
 @Composable
 private fun KeyPadFourLeftHandPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		KeyPad(
 			onNumberClick = { },
 			onNumberLongClick = { },
@@ -317,7 +317,7 @@ private fun KeyPadFourLeftHandPreview() {
 @Preview
 @Composable
 private fun KeyPadSixteenPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		KeyPad(
 			onNumberClick = { },
 			onNumberLongClick = { },
@@ -339,7 +339,7 @@ private fun KeyPadSixteenPreview() {
 @Preview
 @Composable
 private fun KeyPadSixteenLeftPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		KeyPad(
 			onNumberClick = { },
 			onNumberLongClick = { },

--- a/feature/game/src/main/java/com/example/feature/game/components/PostGameActions.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/PostGameActions.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp

--- a/feature/game/src/main/java/com/example/feature/game/components/PostGameActions.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/PostGameActions.kt
@@ -26,11 +26,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.feature.uicore.theme.LocalPadding
 import com.example.feature.uicore.theme.LocalSudokuTypography
-import com.example.feature.uicore.theme.SudokuSlayerTheme
 import com.example.sudokuslayer.feature.game.R
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -122,10 +123,10 @@ internal fun PostGameActions(
 	}
 }
 
-@Preview
+@PreviewLightDark
 @Composable
 private fun PostGameActionsPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		PostGameActions(
 			onViewSummary = { },
 			onPlayAgainClick = { },

--- a/feature/game/src/main/java/com/example/feature/game/components/SudokuBoard.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/SudokuBoard.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.feature.game.theme.LocalSudokuBoardColors
-import com.example.feature.uicore.theme.SudokuSlayerTheme
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.sudoku.model.CellAttributes
 import com.example.sudoku.model.SudokuCellData
 import com.example.sudoku.model.SudokuGrid
@@ -121,7 +121,7 @@ internal fun SudokuBoard(
 @Composable
 private fun SudokuBoardNormalPreview() {
 	val grid = createFilledSudokuGrid(9)
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		SudokuBoard(
 			sudoku = grid,
 			focusedCells = persistentSetOf(Pair(0, 0), Pair(0, 1)),
@@ -135,7 +135,7 @@ private fun SudokuBoardNormalPreview() {
 @Composable
 private fun SudokuBoardBigPreview() {
 	val grid = createFilledSudokuGrid(16)
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		SudokuBoard(
 			sudoku = grid,
 			focusedCells = persistentSetOf(),
@@ -149,7 +149,7 @@ private fun SudokuBoardBigPreview() {
 @Composable
 private fun SudokuBoardSmallPreview() {
 	val grid = createFilledSudokuGrid(4)
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		SudokuBoard(
 			sudoku = grid,
 			focusedCells = persistentSetOf(),

--- a/feature/game/src/main/java/com/example/feature/game/components/SudokuCell.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/SudokuCell.kt
@@ -34,8 +34,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.feature.game.getRoundedBlockShape
 import com.example.feature.game.theme.LocalSudokuBoardColors
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.feature.uicore.modifiers.breathingBorder
-import com.example.feature.uicore.theme.SudokuSlayerTheme
 import com.example.sudoku.model.CellAttributes
 import com.example.sudoku.model.SudokuCellData
 import kotlinx.collections.immutable.PersistentSet
@@ -217,7 +217,7 @@ private fun SudokuCellPreview() {
 	val gridSize = 16
 	val list = createSudokuCellData(gridSize)
 
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		FlowRow(
 			horizontalArrangement = Arrangement.spacedBy(8.dp),
 			verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/feature/game/src/main/java/com/example/feature/game/components/VictoryDialog.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/VictoryDialog.kt
@@ -54,10 +54,10 @@ import com.composables.core.rememberDialogState
 import com.composeunstyled.LocalModalWindow
 import com.example.domain.core.GameDifficulty
 import com.example.domain.core.SudokuGridSize
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.feature.uicore.rememberFormattedTime
 import com.example.feature.uicore.theme.LocalPadding
 import com.example.feature.uicore.theme.LocalSudokuTypography
-import com.example.feature.uicore.theme.SudokuSlayerTheme
 import com.example.feature.uicore.theme.extendedColorScheme
 import com.example.feature.uicore.toLocalizedString
 import com.example.sudokuslayer.feature.game.R
@@ -310,7 +310,7 @@ private fun VictoryStatRow(
 @Preview
 @Composable
 private fun VictoryDialogPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		Surface(
 			color = MaterialTheme.colorScheme.background,
 			modifier = Modifier.fillMaxSize(),

--- a/feature/game/src/main/java/com/example/feature/game/components/VictoryDialog.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/VictoryDialog.kt
@@ -55,6 +55,7 @@ import com.composeunstyled.LocalModalWindow
 import com.example.domain.core.GameDifficulty
 import com.example.domain.core.SudokuGridSize
 import com.example.feature.game.theme.SudokuGameTheme
+import com.example.feature.game.util.ConfettiParties
 import com.example.feature.uicore.rememberFormattedTime
 import com.example.feature.uicore.theme.LocalPadding
 import com.example.feature.uicore.theme.LocalSudokuTypography

--- a/feature/game/src/main/java/com/example/feature/game/components/keypadparts/ActionPad.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/keypadparts/ActionPad.kt
@@ -21,9 +21,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.feature.uicore.navigation.AppIcon
 import com.example.feature.uicore.theme.LocalPadding
-import com.example.feature.uicore.theme.SudokuSlayerTheme
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -98,7 +98,7 @@ private fun LayoutWithOrientation(
 @PreviewLightDark
 @Composable
 private fun ActionPadHorizontalPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		val items = getPreviewItems()
 
 		ActionPad(
@@ -111,7 +111,7 @@ private fun ActionPadHorizontalPreview() {
 @Preview
 @Composable
 private fun ActionPadVerticalPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		val items = getPreviewItems()
 
 		ActionPad(

--- a/feature/game/src/main/java/com/example/feature/game/components/keypadparts/InputModeSwitch.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/keypadparts/InputModeSwitch.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.feature.game.theme.LocalKeyPadColors
-import com.example.feature.uicore.theme.SudokuSlayerTheme
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.sudokuslayer.feature.game.R
 
 @Composable
@@ -64,7 +64,7 @@ fun InputModeSwitch(
 @PreviewLightDark
 @Composable
 private fun InputModeSwitchPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		Row(
 			horizontalArrangement = Arrangement.spacedBy(8.dp),
 		) {

--- a/feature/game/src/main/java/com/example/feature/game/components/keypadparts/KeyPadItem.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/keypadparts/KeyPadItem.kt
@@ -27,8 +27,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.feature.uicore.navigation.AppIcon
-import com.example.feature.uicore.theme.SudokuSlayerTheme
 
 @Composable
 fun KeyPadItem(
@@ -98,7 +98,7 @@ fun KeyPadItem(
 @PreviewLightDark
 @Composable
 private fun KeyboardItemNumberPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		KeyPadItem(
 			text = "5",
 			onClick = { },
@@ -110,7 +110,7 @@ private fun KeyboardItemNumberPreview() {
 @PreviewLightDark
 @Composable
 private fun KeyboardItemIconPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		KeyPadItem(
 			text = "5",
 			icon = AppIcon.VectorIcon(Icons.Default.Clear, "Clear"),

--- a/feature/game/src/main/java/com/example/feature/game/components/keypadparts/NumberPad.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/keypadparts/NumberPad.kt
@@ -17,8 +17,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.example.feature.game.theme.SudokuGameTheme
 import com.example.feature.uicore.theme.LocalPadding
-import com.example.feature.uicore.theme.SudokuSlayerTheme
 import com.example.feature.uicore.theme.extendedColorScheme
 import kotlin.math.sqrt
 
@@ -88,7 +88,7 @@ fun NumberPad(
 @PreviewLightDark
 @Composable
 private fun NumberPadNineItemsPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		NumberPad(
 			onButtonClick = { },
 			onButtonLongClick = { },
@@ -102,7 +102,7 @@ private fun NumberPadNineItemsPreview() {
 @Preview
 @Composable
 private fun NumberPadFourItemsPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		NumberPad(
 			onButtonClick = { },
 			onButtonLongClick = { },
@@ -116,7 +116,7 @@ private fun NumberPadFourItemsPreview() {
 @Preview
 @Composable
 private fun NumberPadSixteenItemsPreview() {
-	SudokuSlayerTheme {
+	SudokuGameTheme {
 		NumberPad(
 			onButtonClick = { },
 			onButtonLongClick = { },

--- a/feature/game/src/main/java/com/example/feature/game/theme/SudokuGameTheme.kt
+++ b/feature/game/src/main/java/com/example/feature/game/theme/SudokuGameTheme.kt
@@ -1,0 +1,32 @@
+package com.example.feature.game.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import com.example.feature.uicore.theme.LocalAppColorScheme
+import com.example.feature.uicore.theme.SudokuSlayerTheme
+
+@Composable
+fun SudokuGameTheme(useSudokuSlayerTheme: Boolean = true, content: @Composable () -> Unit) {
+	val themeContent = @Composable {
+		val colorScheme = LocalAppColorScheme.current
+		val boardColors = rememberBoardColors(colorScheme)
+		val keypadColors = rememberKeypadColors(colorScheme)
+		val hintLogsColors = rememberHintLogsColors(colorScheme)
+
+		CompositionLocalProvider(
+			LocalSudokuBoardColors provides boardColors,
+			LocalKeyPadColors provides keypadColors,
+			LocalHintLogsColors provides hintLogsColors,
+		) {
+			content()
+		}
+	}
+
+	if (useSudokuSlayerTheme) {
+		SudokuSlayerTheme {
+			themeContent()
+		}
+	} else {
+		themeContent()
+	}
+}

--- a/feature/game/src/main/java/com/example/feature/game/util/ConfettiParties.kt
+++ b/feature/game/src/main/java/com/example/feature/game/util/ConfettiParties.kt
@@ -1,4 +1,4 @@
-package com.example.feature.game.components
+package com.example.feature.game.util
 
 import io.github.vinceglb.confettikit.core.Angle
 import io.github.vinceglb.confettikit.core.Party
@@ -20,7 +20,7 @@ internal object ConfettiParties {
 			colors = listOf(0xfce18a, 0xff726d, 0xf4306d, 0xb48def),
 			emitter = Emitter(duration = 100.milliseconds).max(100),
 			position = position,
-			rotation = Rotation.enabled(),
+			rotation = Rotation.Companion.enabled(),
 			fadeOutEnabled = false,
 			shapes = listOf(Shape.Square, Shape.Circle),
 			timeToLive = 7000L,
@@ -35,8 +35,8 @@ internal object ConfettiParties {
 			speed = 10f,
 			maxSpeed = 30f,
 			damping = 0.9f,
-			angle = Angle.RIGHT - 45,
-			spread = Spread.SMALL,
+			angle = Angle.Companion.RIGHT - 45,
+			spread = Spread.Companion.SMALL,
 			colors = listOf(0xfce18a, 0xff726d, 0xf4306d, 0xb48def),
 			emitter = Emitter(duration = 1.seconds).perSecond(30),
 			position = position1,
@@ -56,8 +56,8 @@ internal object ConfettiParties {
 			speed = 10f,
 			maxSpeed = 30f,
 			damping = 0.9f,
-			angle = Angle.TOP,
-			spread = Spread.SMALL,
+			angle = Angle.Companion.TOP,
+			spread = Spread.Companion.SMALL,
 			colors = listOf(0xfce18a, 0xff726d, 0xf4306d, 0xb48def),
 			emitter = Emitter(duration = 2.seconds).perSecond(30),
 			position = position,
@@ -70,8 +70,8 @@ internal object ConfettiParties {
 			speed = 0f,
 			maxSpeed = 15f,
 			damping = 0.9f,
-			angle = Angle.BOTTOM,
-			spread = Spread.ROUND,
+			angle = Angle.Companion.BOTTOM,
+			spread = Spread.Companion.ROUND,
 			colors = listOf(0xfce18a, 0xff726d, 0xf4306d, 0xb48def),
 			emitter = Emitter(duration = 2.5.seconds).perSecond(100),
 			position = Position.Relative(0.0, 0.0).between(Position.Relative(1.0, 0.0)),

--- a/feature/uicore/src/main/java/com/example/feature/uicore/theme/SudokuSlayerTheme.kt
+++ b/feature/uicore/src/main/java/com/example/feature/uicore/theme/SudokuSlayerTheme.kt
@@ -23,7 +23,7 @@ fun SudokuSlayerTheme(
 			extendedLight
 		}
 	}
-	val colorScheme = remember(colorScheme) {
+	val materialColorScheme = remember(colorScheme) {
 		when (colorScheme) {
 			is ColorScheme.Mocha -> mochaColorScheme
 			is ColorScheme.Macchiato -> macchiatoColorScheme
@@ -33,11 +33,12 @@ fun SudokuSlayerTheme(
 	}
 
 	CompositionLocalProvider(
+		LocalAppColorScheme provides colorScheme,
 		LocalExtendedColorScheme provides extendedColorScheme,
 		LocalSudokuTypography provides AppTypography,
 	) {
 		MaterialExpressiveTheme(
-			colorScheme = colorScheme,
+			colorScheme = materialColorScheme,
 		) {
 			content()
 		}


### PR DESCRIPTION
This pull request focuses on refactoring the theme system for the Sudoku application by replacing the `SudokuSlayerTheme` with the new `SudokuGameTheme`. It also removes unused imports and cleans up redundant code. The changes fix PreviewLightDark always showing one color scheme for game module components.

### Theme Refactoring

* Replaced `SudokuSlayerTheme` with `SudokuGameTheme` across multiple files and components, including previews for `SudokuGameScreen`, `HintBottomSheetScaffold`, `HintStepCard`, `HintsDialog`, `KeyPad`, `PostGameActions`, `SudokuBoard`, and `SudokuCell`. This ensures consistent usage of the new theme system. [[1]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L376-R362) [[2]](diffhunk://#diff-d7de2ff7caec3714d692293385455fe2ef51446e87b38e5504efb2f4734ec34cL221-R221) [[3]](diffhunk://#diff-d805b5953ea60ed6d6669d3434e2be01e1d2cdd346d9127823028b498697a8d7L168-R168) [[4]](diffhunk://#diff-22df986388c0a0be066012fc17d4d5267ba6ae7a6bdb080984ebf090df1d6121L126-R126) [[5]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56L254-R254) [[6]](diffhunk://#diff-83e7b7cd4104c81721ca451666039bf970c869d8ba2933945fd0033163769346L125-R128) [[7]](diffhunk://#diff-4303c8291762e056d81819c050c033902dbc3b604cad5e3c4a8d751040ae9ff6L124-R124) [[8]](diffhunk://#diff-800d68450a18a0ac9ec89865c028a28a822083b4b026e628d578af6413013c82L220-R220) [[9]](diffhunk://#diff-bb25cafe6be7c5ae90e3f0b60ddaf64c82f5dd3466f14c0745010914e8cd1b1aL313-R314)

### Code Cleanup

* Removed unused `CompositionLocalProvider` and related local color schemes (`LocalAppColorScheme`, `LocalHintLogsColors`, `LocalKeyPadColors`, `LocalSudokuBoardColors`) in favor of the centralized `SudokuGameTheme`. This simplifies the code and reduces redundancy. [[1]](diffhunk://#diff-d78e5c66d24cea6223a8fba4c52e56a0e04209e9860c519276b1c4d2378e9dd0L101) [[2]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L88-R80)

### Import Optimization

* Removed unused imports across multiple files, such as `LocalAppColorScheme` and other theme-related imports, to streamline the codebase. [[1]](diffhunk://#diff-d78e5c66d24cea6223a8fba4c52e56a0e04209e9860c519276b1c4d2378e9dd0L14) [[2]](diffhunk://#diff-d78e5c66d24cea6223a8fba4c52e56a0e04209e9860c519276b1c4d2378e9dd0L44) [[3]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L26) [[4]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L60-R59)

### Preview Updates

* Updated all component previews to use `SudokuGameTheme` instead of `SudokuSlayerTheme`, ensuring they reflect the new theme structure during development. [[1]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L402-R386) [[2]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L428-R412) [[3]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56L276-R276) [[4]](diffhunk://#diff-4303c8291762e056d81819c050c033902dbc3b604cad5e3c4a8d751040ae9ff6L138-R138) [[5]](diffhunk://#diff-800d68450a18a0ac9ec89865c028a28a822083b4b026e628d578af6413013c82L220-R220)

These changes collectively modernize the theme implementation and improve code maintainability by consolidating theme usage and removing unnecessary elements.