### PR TITLE
Feat: add content descriptions to InputModeSwitch

### DIFF
--- a/feature/game/src/main/java/com/example/feature/game/components/keypadparts/InputModeSwitch.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/keypadparts/InputModeSwitch.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -30,6 +31,12 @@ fun InputModeSwitch(
 	modifier: Modifier = Modifier,
 	iconSize: Dp = 40.dp,
 ) {
+	val contentDesc = if (checked) {
+		stringResource(R.string.input_switch_action_to_numbers)
+	} else {
+		stringResource(R.string.input_switch_action_to_notes)
+	}
+
 	IconToggleButton(
 		checked = checked,
 		onCheckedChange = { onClick(it) },
@@ -56,7 +63,7 @@ fun InputModeSwitch(
 			} else {
 				painterResource(R.drawable.tag)
 			},
-			contentDescription = "Input mode switch",
+			contentDescription = contentDesc,
 			modifier = Modifier.size(iconSize),
 		)
 	}

--- a/feature/game/src/main/res/values/strings.xml
+++ b/feature/game/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
 	<string name="content_desc_collapse">Collapse</string>
 	<string name="content_desc_expand">Expand</string>
 	<string name="content_desc_explain_hint">Explain hint</string>
+    <string name="input_switch_action_to_numbers">Switch to Number input mode</string>
+	<string name="input_switch_action_to_notes">Switch to Note input mode</string>
 </resources>


### PR DESCRIPTION
This commit adds dynamic content descriptions to the `InputModeSwitch` composable.

The content description now reflects the action that will occur when the switch is toggled:
- "Switch to Number input mode" when the switch is currently in "Notes" mode (unchecked) and will switch to "Numbers" (checked).
- "Switch to Note input mode" when the switch is currently in "Numbers" mode (checked) and will switch to "Notes" (unchecked).

String resources for these descriptions have been added to `strings.xml`.