### PR TITLE
Chore: update Android Gradle Plugin version to 8.11.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # Android
-agp = "8.11.0"
+agp = "8.11.1"
 android-compileSdk = "36"
 android-minSdk = "26"
 android-targetSdk = "35"


### PR DESCRIPTION
This pull request includes a version update for the Android Gradle Plugin (AGP) in the `gradle/libs.versions.toml` file.

* Updated the AGP version from `8.11.0` to `8.11.1` to ensure compatibility with the latest features and bug fixes. (`[gradle/libs.versions.tomlL4-R4](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL4-R4)`)