### PR TITLE
Feat/show digit remaining count

### DIFF
--- a/data/settings/src/main/java/com/example/data/settings/AndroidSettingsRepository.kt
+++ b/data/settings/src/main/java/com/example/data/settings/AndroidSettingsRepository.kt
@@ -61,6 +61,10 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 		SettingsPreferenceKeys.TimerVisibility,
 	).map { it == true }
 
+	override val remainingDigitCounts: Flow<Boolean> = preferenceStorage.getAsFlow(
+		SettingsPreferenceKeys.RemainingDigitCounts,
+	).map { it == true }
+
 	override suspend fun setDarkMode(darkMode: DarkMode) {
 		preferenceStorage.set(SettingsPreferenceKeys.DarkMode, darkMode.displayName)
 	}
@@ -111,6 +115,13 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 		preferenceStorage.set(
 			SettingsPreferenceKeys.TimerVisibility,
 			timerVisibility,
+		)
+	}
+
+	override suspend fun setRemainingDigitCounts(remainingDigitCounts: Boolean) {
+		preferenceStorage.set(
+			SettingsPreferenceKeys.RemainingDigitCounts,
+			remainingDigitCounts,
 		)
 	}
 

--- a/data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.kt
+++ b/data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.kt
@@ -53,4 +53,9 @@ interface SettingsPreferenceKeys {
 		name = "timer_visibility",
 		defaultValue = true,
 	)
+
+	data object RemainingDigitCounts : PreferenceStorage.Key.BooleanKey(
+		name = "remaining_digit_counts",
+		defaultValue = true,
+	)
 }

--- a/domain/settings/src/main/java/com/example/domain/settings/SettingsRepository.kt
+++ b/domain/settings/src/main/java/com/example/domain/settings/SettingsRepository.kt
@@ -16,6 +16,7 @@ interface SettingsRepository {
 	val highlightMatchingNumbers: Flow<Boolean>
 	val highlightInvalidNumbers: Flow<Boolean>
 	val timerVisibility: Flow<Boolean>
+	val remainingDigitCounts: Flow<Boolean>
 
 	suspend fun setDarkMode(darkMode: DarkMode)
 
@@ -38,6 +39,8 @@ interface SettingsRepository {
 	suspend fun setHighlightInvalidNumbers(highlightInvalidNumbers: Boolean)
 
 	suspend fun setTimerVisibility(timerVisibility: Boolean)
+
+	suspend fun setRemainingDigitCounts(remainingDigitCounts: Boolean)
 
 	fun getAvailableColorSchemes(): List<ColorScheme>
 

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
@@ -59,7 +59,9 @@ import com.example.feature.game.model.SudokuGameUiState
 import com.example.feature.game.theme.SudokuGameTheme
 import com.example.sudoku.model.SudokuGrid
 import com.example.sudokuslayer.feature.game.R
+import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import kotlin.random.Random
@@ -76,6 +78,7 @@ internal fun SudokuGameScreen(
 	val elapsedTime by viewModel.elapsedTime.collectAsStateWithLifecycle()
 	val uiState: SudokuGameUiState by viewModel.uiState.collectAsStateWithLifecycle()
 	val game by viewModel.game.collectAsStateWithLifecycle()
+	val remainingDigitCounts by viewModel.remainingDigitCounts.collectAsStateWithLifecycle()
 
 	SudokuGameTheme(useSudokuSlayerTheme = false) {
 		LifecycleResumeEffect(Unit) {
@@ -88,6 +91,7 @@ internal fun SudokuGameScreen(
 		SudokuGameScreenContent(
 			uiState = uiState,
 			game = game,
+			remainingDigitCounts = remainingDigitCounts,
 			onEvent = {
 				viewModel.onEvent(it)
 			},
@@ -105,6 +109,7 @@ internal fun SudokuGameScreen(
 private fun SudokuGameScreenContent(
 	uiState: SudokuGameUiState,
 	game: Game,
+	remainingDigitCounts: PersistentMap<Int, Int>,
 	onEvent: (Event) -> Unit,
 	elapsedTime: () -> Long,
 	openDrawer: () -> Unit,
@@ -263,6 +268,7 @@ private fun SudokuGameScreenContent(
 							GameState.LOADING -> {}
 							GameState.PLAYING -> {
 								KeyPad(
+									remainingDigitCounts = remainingDigitCounts,
 									onNumberClick = { onEvent(Event.InputNumber(it)) },
 									onNumberLongClick = { onEvent(Event.LongInputNumber(it)) },
 									onClearClick = { onEvent(Event.ClearCell) },
@@ -315,6 +321,7 @@ private fun SudokuGameScreenContent(
 							GameState.LOADING -> {}
 							GameState.PLAYING -> {
 								KeyPad(
+									remainingDigitCounts = remainingDigitCounts,
 									onNumberClick = { onEvent(Event.InputNumber(it)) },
 									onNumberLongClick = { onEvent(Event.LongInputNumber(it)) },
 									onClearClick = { onEvent(Event.ClearCell) },
@@ -368,6 +375,7 @@ private fun SudokuGameScreenPreview() {
 				hintsUsed = 0,
 				difficulty = GameDifficulty.Easy,
 			),
+			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
 			onEvent = {},
 			elapsedTime = { 1 },
 			openDrawer = {},
@@ -392,6 +400,7 @@ private fun SudokuGameScreenSixteenPreview() {
 				hintsUsed = 0,
 				difficulty = GameDifficulty.Easy,
 			),
+			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
 			onEvent = {},
 			elapsedTime = { 1 },
 			openDrawer = {},
@@ -422,6 +431,7 @@ private fun SudokuGameScreenFourPreview() {
 				hintsUsed = 0,
 				difficulty = GameDifficulty.Easy,
 			),
+			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
 			onEvent = {},
 			elapsedTime = { 1 },
 			openDrawer = {},

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
@@ -412,7 +412,7 @@ private fun SudokuGameScreenFourPreview() {
 			uiState =
 			SudokuGameUiState(
 				isLeftHandMode = true,
-				gameState = GameState.VICTORY,
+				gameState = GameState.PLAYING,
 			),
 			game =
 			Game(

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
@@ -262,7 +262,7 @@ private fun SudokuGameScreenContent(
 					AnimatedContent(
 						targetState = uiState.gameState,
 						contentAlignment = Alignment.Center,
-						modifier = Modifier.weight(0.8f),
+						modifier = Modifier.weight(1f),
 					) { state ->
 						when (state) {
 							GameState.LOADING -> {}

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -29,10 +29,13 @@ import com.example.sudoku.model.fillNotes
 import com.example.sudoku.solver.ClassicSudokuSolver
 import com.example.sudoku.solver.Hint
 import com.example.sudoku.solver.HintType
+import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.plus
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -43,6 +46,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -94,6 +98,13 @@ internal class SudokuGameViewModel(
 			started = SharingStarted.WhileSubscribed(5000L),
 			initialValue = 0L,
 		)
+	val remainingDigitCounts: StateFlow<PersistentMap<Int, Int>> = game.map {
+		calculateRemainingCounts(it.grid).toPersistentMap()
+	}.stateIn(
+		scope = viewModelScope,
+		started = SharingStarted.WhileSubscribed(5000L),
+		initialValue = persistentMapOf(),
+	)
 
 	private val stringProvider by lazy {
 		AndroidHintStringProvider(application)
@@ -603,5 +614,14 @@ internal class SudokuGameViewModel(
 				)
 			}
 		}
+	}
+
+	private fun calculateRemainingCounts(sudokuGrid: SudokuGrid): Map<Int, Int> {
+		val remainingDigitCounts = mutableMapOf<Int, Int>()
+		val max = sudokuGrid.gridSize
+		for (i in 1..max) {
+			remainingDigitCounts[i] = max - sudokuGrid.data.count { it.number == i }
+		}
+		return remainingDigitCounts
 	}
 }

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -46,7 +46,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -98,8 +97,15 @@ internal class SudokuGameViewModel(
 			started = SharingStarted.WhileSubscribed(5000L),
 			initialValue = 0L,
 		)
-	val remainingDigitCounts: StateFlow<PersistentMap<Int, Int>> = game.map {
-		calculateRemainingCounts(it.grid).toPersistentMap()
+	val remainingDigitCounts: StateFlow<PersistentMap<Int, Int>> = combine(
+		game,
+		settingsRepository.remainingDigitCounts,
+	) { game, showRemainingDigitCounts ->
+		if (showRemainingDigitCounts) {
+			calculateRemainingCounts(game.grid).toPersistentMap()
+		} else {
+			persistentMapOf()
+		}
 	}.stateIn(
 		scope = viewModelScope,
 		started = SharingStarted.WhileSubscribed(5000L),

--- a/feature/game/src/main/java/com/example/feature/game/components/KeyPad.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/KeyPad.kt
@@ -34,12 +34,15 @@ import com.example.feature.uicore.navigation.AppIcon
 import com.example.feature.uicore.theme.LocalPadding
 import com.example.sudokuslayer.feature.game.R
 import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 import kotlin.math.sqrt
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 internal fun KeyPad(
+	remainingDigitCounts: PersistentMap<Int, Int>,
 	onNumberClick: (Int) -> Unit,
 	onNumberLongClick: (Int) -> Unit,
 	onClearClick: () -> Unit,
@@ -136,6 +139,7 @@ internal fun KeyPad(
 							)
 						}
 						NumberPad(
+							remainingDigitCounts = remainingDigitCounts,
 							gridSize = gridSize,
 							onButtonClick = onNumberClick,
 							onButtonLongClick = onNumberLongClick,
@@ -179,6 +183,7 @@ internal fun KeyPad(
 							contentColor = LocalKeyPadColors.current.actionPadOnBackground,
 						)
 						NumberPad(
+							remainingDigitCounts = remainingDigitCounts,
 							gridSize = gridSize,
 							onButtonClick = onNumberClick,
 							onButtonLongClick = onNumberLongClick,
@@ -249,6 +254,7 @@ private fun getMiddleActionPadItems(
 private fun KeyPadPreview() {
 	SudokuGameTheme {
 		KeyPad(
+			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 2, 3 to 3),
 			onNumberClick = { },
 			onNumberLongClick = { },
 			onClearClick = { },
@@ -270,6 +276,7 @@ private fun KeyPadPreview() {
 private fun KeyPadFourPreview() {
 	SudokuGameTheme {
 		KeyPad(
+			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 2, 3 to 3),
 			onNumberClick = { },
 			onNumberLongClick = { },
 			onClearClick = { },
@@ -291,6 +298,7 @@ private fun KeyPadFourPreview() {
 private fun KeyPadFourLeftHandPreview() {
 	SudokuGameTheme {
 		KeyPad(
+			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 2, 3 to 3),
 			onNumberClick = { },
 			onNumberLongClick = { },
 			onClearClick = { },
@@ -312,6 +320,7 @@ private fun KeyPadFourLeftHandPreview() {
 private fun KeyPadSixteenPreview() {
 	SudokuGameTheme {
 		KeyPad(
+			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 2, 3 to 3),
 			onNumberClick = { },
 			onNumberLongClick = { },
 			onClearClick = { },
@@ -333,6 +342,7 @@ private fun KeyPadSixteenPreview() {
 private fun KeyPadSixteenLeftPreview() {
 	SudokuGameTheme {
 		KeyPad(
+			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 2, 3 to 3),
 			onNumberClick = { },
 			onNumberLongClick = { },
 			onClearClick = { },

--- a/feature/game/src/main/java/com/example/feature/game/components/KeyPad.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/KeyPad.kt
@@ -143,7 +143,6 @@ internal fun KeyPad(
 							gridSize = gridSize,
 							onButtonClick = onNumberClick,
 							onButtonLongClick = onNumberLongClick,
-							noteMode = noteMode,
 							itemSize = itemSize,
 						)
 					}
@@ -187,7 +186,6 @@ internal fun KeyPad(
 							gridSize = gridSize,
 							onButtonClick = onNumberClick,
 							onButtonLongClick = onNumberLongClick,
-							noteMode = noteMode,
 							itemSize = itemSize,
 						)
 					}

--- a/feature/game/src/main/java/com/example/feature/game/components/keypadparts/KeyPadItem.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/keypadparts/KeyPadItem.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -101,11 +102,15 @@ internal fun KeyPadDigitItem(
 	digit: Int,
 	remainingCount: Int,
 	onClick: () -> Unit,
-	onLongClick: (() -> Unit)?,
+	onLongClick: (() -> Unit),
 	modifier: Modifier = Modifier,
 	containerColor: Color = MaterialTheme.colorScheme.primaryContainer,
 	contentColor: Color = MaterialTheme.colorScheme.onPrimaryContainer,
+	completedColor: Color = MaterialTheme.colorScheme.surfaceContainer,
+	completedContentColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
 ) {
+	val containerColor = if (remainingCount == 0) completedColor else containerColor
+	val contentColor = if (remainingCount == 0) completedContentColor else contentColor
 	BaseKeyPadItem(
 		onClick = onClick,
 		onLongClick = onLongClick,
@@ -122,6 +127,7 @@ internal fun KeyPadDigitItem(
 				autoSize = TextAutoSize.StepBased(),
 				textAlign = TextAlign.Center,
 				style = TextStyle(platformStyle = PlatformTextStyle(includeFontPadding = false)),
+				fontWeight = FontWeight.Bold,
 				maxLines = 1,
 				modifier =
 				Modifier
@@ -226,14 +232,21 @@ private fun KeyboardItemDigitPreview() {
 				digit = 9,
 				remainingCount = 3,
 				onClick = { },
-				onLongClick = null,
+				onLongClick = { },
 				modifier = Modifier.size(80.dp),
 			)
 			KeyPadDigitItem(
 				digit = 16,
 				remainingCount = 13,
 				onClick = { },
-				onLongClick = null,
+				onLongClick = { },
+				modifier = Modifier.size(80.dp),
+			)
+			KeyPadDigitItem(
+				digit = 10,
+				remainingCount = 0,
+				onClick = { },
+				onLongClick = { },
 				modifier = Modifier.size(80.dp),
 			)
 		}

--- a/feature/game/src/main/java/com/example/feature/game/components/keypadparts/KeyPadItem.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/keypadparts/KeyPadItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -26,6 +27,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -93,6 +96,52 @@ internal fun KeyPadTextItem(
 	}
 }
 
+@Composable
+internal fun KeyPadDigitItem(
+	digit: Int,
+	remainingCount: Int,
+	onClick: () -> Unit,
+	onLongClick: (() -> Unit)?,
+	modifier: Modifier = Modifier,
+	containerColor: Color = MaterialTheme.colorScheme.primaryContainer,
+	contentColor: Color = MaterialTheme.colorScheme.onPrimaryContainer,
+) {
+	BaseKeyPadItem(
+		onClick = onClick,
+		onLongClick = onLongClick,
+		modifier = modifier,
+		containerColor = containerColor,
+		contentColor = contentColor,
+	) {
+		Column(
+			horizontalAlignment = Alignment.CenterHorizontally,
+		) {
+			Text(
+				text = digit.toString(),
+				color = contentColor,
+				autoSize = TextAutoSize.StepBased(),
+				textAlign = TextAlign.Center,
+				style = TextStyle(platformStyle = PlatformTextStyle(includeFontPadding = false)),
+				maxLines = 1,
+				modifier =
+				Modifier
+					.weight(0.7f),
+			)
+			Text(
+				text = remainingCount.toString(),
+				color = contentColor,
+				autoSize = TextAutoSize.StepBased(),
+				textAlign = TextAlign.Center,
+				style = TextStyle(platformStyle = PlatformTextStyle(includeFontPadding = false)),
+				maxLines = 1,
+				modifier =
+				Modifier
+					.weight(0.3f),
+			)
+		}
+	}
+}
+
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun KeyPadIconItem(
@@ -138,12 +187,20 @@ internal fun KeyPadIconItem(
 @Composable
 private fun KeyboardItemNumberPreview() {
 	SudokuGameTheme {
-		KeyPadTextItem(
-			text = "5",
-			onClick = { },
-			onLongClick = null,
-			modifier = Modifier.size(80.dp),
-		)
+		Column {
+			KeyPadTextItem(
+				text = "5",
+				onClick = { },
+				onLongClick = null,
+				modifier = Modifier.size(80.dp),
+			)
+			KeyPadTextItem(
+				text = "16",
+				onClick = { },
+				onLongClick = null,
+				modifier = Modifier.size(80.dp),
+			)
+		}
 	}
 }
 
@@ -157,5 +214,28 @@ private fun KeyboardItemIconPreview() {
 			onLongClick = null,
 			modifier = Modifier.size(80.dp),
 		)
+	}
+}
+
+@PreviewLightDark
+@Composable
+private fun KeyboardItemDigitPreview() {
+	SudokuGameTheme {
+		Column {
+			KeyPadDigitItem(
+				digit = 9,
+				remainingCount = 3,
+				onClick = { },
+				onLongClick = null,
+				modifier = Modifier.size(80.dp),
+			)
+			KeyPadDigitItem(
+				digit = 16,
+				remainingCount = 13,
+				onClick = { },
+				onLongClick = null,
+				modifier = Modifier.size(80.dp),
+			)
+		}
 	}
 }

--- a/feature/game/src/main/java/com/example/feature/game/components/keypadparts/NumberPad.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/keypadparts/NumberPad.kt
@@ -19,11 +19,14 @@ import androidx.compose.ui.unit.dp
 import com.example.feature.game.theme.SudokuGameTheme
 import com.example.feature.uicore.theme.LocalPadding
 import com.example.feature.uicore.theme.extendedColorScheme
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentMapOf
 import kotlin.math.sqrt
 
 @Composable
 internal fun NumberPad(
 	gridSize: Int,
+	remainingDigitCounts: PersistentMap<Int, Int>,
 	onButtonClick: (Int) -> Unit,
 	onButtonLongClick: (Int) -> Unit,
 	noteMode: Boolean,
@@ -66,15 +69,28 @@ internal fun NumberPad(
 				verticalAlignment = Alignment.CenterVertically,
 			) {
 				for (number in row) {
-					KeyPadTextItem(
-						text = number.toString(),
-						onClick = { onButtonClick(number) },
-						onLongClick = { onButtonLongClick(number) },
-						containerColor = keyColor,
-						contentColor = textColor,
-						modifier = Modifier
-							.size(itemSize),
-					)
+					if (number in remainingDigitCounts) {
+						KeyPadDigitItem(
+							digit = number,
+							remainingCount = remainingDigitCounts[number]!!,
+							onClick = { onButtonClick(number) },
+							onLongClick = { onButtonLongClick(number) },
+							containerColor = keyColor,
+							contentColor = textColor,
+							modifier = Modifier
+								.size(itemSize),
+						)
+					} else {
+						KeyPadTextItem(
+							text = number.toString(),
+							onClick = { onButtonClick(number) },
+							onLongClick = { onButtonLongClick(number) },
+							containerColor = keyColor,
+							contentColor = textColor,
+							modifier = Modifier
+								.size(itemSize),
+						)
+					}
 				}
 			}
 		}
@@ -86,6 +102,7 @@ internal fun NumberPad(
 private fun NumberPadNineItemsPreview() {
 	SudokuGameTheme {
 		NumberPad(
+			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
 			onButtonClick = { },
 			onButtonLongClick = { },
 			noteMode = false,
@@ -100,6 +117,7 @@ private fun NumberPadNineItemsPreview() {
 private fun NumberPadFourItemsPreview() {
 	SudokuGameTheme {
 		NumberPad(
+			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
 			onButtonClick = { },
 			onButtonLongClick = { },
 			noteMode = false,
@@ -114,6 +132,7 @@ private fun NumberPadFourItemsPreview() {
 private fun NumberPadSixteenItemsPreview() {
 	SudokuGameTheme {
 		NumberPad(
+			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
 			onButtonClick = { },
 			onButtonLongClick = { },
 			noteMode = false,

--- a/feature/game/src/main/java/com/example/feature/game/components/keypadparts/NumberPad.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/keypadparts/NumberPad.kt
@@ -29,7 +29,6 @@ internal fun NumberPad(
 	remainingDigitCounts: PersistentMap<Int, Int>,
 	onButtonClick: (Int) -> Unit,
 	onButtonLongClick: (Int) -> Unit,
-	noteMode: Boolean,
 	modifier: Modifier = Modifier,
 	itemSize: Dp = 48.dp,
 ) {
@@ -44,19 +43,8 @@ internal fun NumberPad(
 		},
 	)
 
-	val keyColor =
-		if (noteMode) {
-			MaterialTheme.extendedColorScheme.pink.colorContainer
-		} else {
-			MaterialTheme.extendedColorScheme.lavender.colorContainer
-		}
-
-	val textColor =
-		if (noteMode) {
-			MaterialTheme.extendedColorScheme.pink.onColorContainer
-		} else {
-			MaterialTheme.extendedColorScheme.lavender.onColorContainer
-		}
+	val keyColor = MaterialTheme.extendedColorScheme.lavender.colorContainer
+	val textColor = MaterialTheme.extendedColorScheme.lavender.onColorContainer
 
 	Column(
 		modifier = modifier,
@@ -72,7 +60,7 @@ internal fun NumberPad(
 					if (number in remainingDigitCounts) {
 						KeyPadDigitItem(
 							digit = number,
-							remainingCount = remainingDigitCounts[number]!!,
+							remainingCount = remainingDigitCounts.getOrDefault(number, 0),
 							onClick = { onButtonClick(number) },
 							onLongClick = { onButtonLongClick(number) },
 							containerColor = keyColor,
@@ -105,7 +93,6 @@ private fun NumberPadNineItemsPreview() {
 			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
 			onButtonClick = { },
 			onButtonLongClick = { },
-			noteMode = false,
 			gridSize = 9,
 			modifier = Modifier.padding(16.dp),
 		)
@@ -120,7 +107,6 @@ private fun NumberPadFourItemsPreview() {
 			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
 			onButtonClick = { },
 			onButtonLongClick = { },
-			noteMode = false,
 			gridSize = 4,
 			modifier = Modifier.padding(16.dp),
 		)
@@ -135,7 +121,6 @@ private fun NumberPadSixteenItemsPreview() {
 			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
 			onButtonClick = { },
 			onButtonLongClick = { },
-			noteMode = false,
 			gridSize = 16,
 			modifier = Modifier.padding(16.dp),
 		)

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsScreen.kt
@@ -178,6 +178,13 @@ private fun SettingsScreenContent(
 					modifier = Modifier.fillMaxWidth(),
 				)
 				SettingSwitchItem(
+					title = stringResource(R.string.gameplay_show_remaining_digit_counts),
+					value = uiState.gameplay.remainingDigitCounts,
+					description = stringResource(R.string.gameplay_show_remaining_digit_counts_desc),
+					onValueChange = { onEvent(SettingsViewModel.Event.ToggleRemainingDigitCounts(it)) },
+					modifier = Modifier.fillMaxWidth(),
+				)
+				SettingSwitchItem(
 					title = "Auto clear notes",
 					value = uiState.gameplay.autoClearNotes,
 					description = "Clear notes when a number is input",

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsViewModel.kt
@@ -36,6 +36,7 @@ internal data class GameplaySettings(
 	val highlightMatching: Boolean = true,
 	val highlightInvalid: Boolean = true,
 	val timerVisibility: Boolean = true,
+	val remainingDigitCounts: Boolean = true,
 )
 
 internal class SettingsViewModel(private val settingsRepository: SettingsRepository) :
@@ -82,12 +83,14 @@ internal class SettingsViewModel(private val settingsRepository: SettingsReposit
 		settingsRepository.highlightMatchingNumbers,
 		settingsRepository.highlightInvalidNumbers,
 		settingsRepository.timerVisibility,
-	) { autoClearNotes, highlightMatching, highlightInvalid, timerVisibility ->
+		settingsRepository.remainingDigitCounts,
+	) { autoClearNotes, highlightMatching, highlightInvalid, timerVisibility, remainingDigitCounts ->
 		GameplaySettings(
 			autoClearNotes = autoClearNotes,
 			highlightMatching = highlightMatching,
 			highlightInvalid = highlightInvalid,
 			timerVisibility = timerVisibility,
+			remainingDigitCounts = remainingDigitCounts,
 		)
 	}.stateIn(
 		scope = viewModelScope,
@@ -129,6 +132,7 @@ internal class SettingsViewModel(private val settingsRepository: SettingsReposit
 		data class ToggleHighlightMatching(val highlightMatching: Boolean) : Event
 		data class ToggleHighlightInvalid(val highlightInvalid: Boolean) : Event
 		data class ToggleTimerVisibility(val timerVisibility: Boolean) : Event
+		data class ToggleRemainingDigitCounts(val remainingDigitCounts: Boolean) : Event
 	}
 
 	fun onEvent(event: Event) {
@@ -147,6 +151,7 @@ internal class SettingsViewModel(private val settingsRepository: SettingsReposit
 			is Event.ToggleHighlightMatching -> toggleHighlightMatching(event.highlightMatching)
 			is Event.ToggleHighlightInvalid -> toggleHighlightInvalid(event.highlightInvalid)
 			is Event.ToggleTimerVisibility -> toggleTimerVisibility(event.timerVisibility)
+			is Event.ToggleRemainingDigitCounts -> toggleRemainingDigitCounts(event.remainingDigitCounts)
 		}
 	}
 
@@ -214,6 +219,12 @@ internal class SettingsViewModel(private val settingsRepository: SettingsReposit
 		viewModelScope.launch {
 			// When timerVisibility is true (user wants to hide), we save visibility as false.
 			settingsRepository.setTimerVisibility(!timerVisibility)
+		}
+	}
+
+	private fun toggleRemainingDigitCounts(remainingDigitCounts: Boolean) {
+		viewModelScope.launch {
+			settingsRepository.setRemainingDigitCounts(remainingDigitCounts)
 		}
 	}
 }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -7,4 +7,6 @@
 	<string name="gameplay_mark_invalid">Mark Invalid Numbers</string>
 	<string name="gameplay_hide_in_game_timer">Hide In-Game Timer</string>
 	<string name="gameplay_hide_in_game_timer_desc">Hides the timer during gameplay so you can solve at your own pace. Your final time is still recorded.</string>
+    <string name="gameplay_show_remaining_digit_counts">Show Remaining Digit Counts</string>
+	<string name="gameplay_show_remaining_digit_counts_desc">Display a small number below each digit on the keypad indicating how many are left to place.</string>
 </resources>

--- a/feature/statistics/src/main/java/com/example/feature/statistics/insights/components/InsightsFab.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/insights/components/InsightsFab.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.feature.statistics.LoadingState


### PR DESCRIPTION
This pull request introduces a new feature to display the remaining counts of digits in the Sudoku game and integrates it throughout the game UI and logic. The changes span across the settings, view model, and UI components, ensuring a seamless addition of this functionality. Below are the most important changes grouped by theme:

### Settings and Repository Updates:
* Added a new preference key `RemainingDigitCounts` in `SettingsPreferenceKeys` to store and retrieve the setting for showing remaining digit counts (`data/settings/src/main/java/com/example/data/settings/SettingsPreferenceKeys.kt`).
* Updated the `SettingsRepository` interface and its implementation in `AndroidSettingsRepository` to include methods and flows for managing the `remainingDigitCounts` setting (`domain/settings/src/main/java/com/example/domain/settings/SettingsRepository.kt`, `data/settings/src/main/java/com/example/data/settings/AndroidSettingsRepository.kt`). [[1]](diffhunk://#diff-15e7703f8a985933c09f17129d6df65b8431d17d53c41c297e494daa0b476e2bR19) [[2]](diffhunk://#diff-15e7703f8a985933c09f17129d6df65b8431d17d53c41c297e494daa0b476e2bR43-R44) [[3]](diffhunk://#diff-c9523922259fc2d4e847df28b37bf1582833548cc0ae8bba5a48d879da67685bR64-R67) [[4]](diffhunk://#diff-c9523922259fc2d4e847df28b37bf1582833548cc0ae8bba5a48d879da67685bR121-R127)

### ViewModel Enhancements:
* Added a `remainingDigitCounts` `StateFlow` in `SudokuGameViewModel` to calculate and expose the remaining counts of digits based on the Sudoku grid and the `remainingDigitCounts` setting (`feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt`). [[1]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R100-R113) [[2]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R624-R632)

### UI Integration:
* Integrated `remainingDigitCounts` into the `SudokuGameScreen` and passed it down to the `KeyPad` component for display (`feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt`). [[1]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8R81) [[2]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8R94) [[3]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8R112) [[4]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L260-R271) [[5]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8R324)

### KeyPad and KeyPadItem Updates:
* Enhanced the `KeyPad` component to accept and display `remainingDigitCounts`. Added a new `KeyPadDigitItem` composable to show digits along with their remaining counts (`feature/game/src/main/java/com/example/feature/game/components/KeyPad.kt`, `feature/game/src/main/java/com/example/feature/game/components/keypadparts/KeyPadItem.kt`). (Ffa1989cL29R29, [[1]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R142-L142) [[2]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R185-L185) [[3]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R255) [[4]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R277) [[5]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R299) [[6]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R321) [[7]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R343) [[8]](diffhunk://#diff-6a6d21ccbaef7a7771d81ddf157379d5ead76f0b8dcdbaa4ec86fdf66751fd4fR100-R150) [[9]](diffhunk://#diff-6a6d21ccbaef7a7771d81ddf157379d5ead76f0b8dcdbaa4ec86fdf66751fd4fR196-R209) [[10]](diffhunk://#diff-6a6d21ccbaef7a7771d81ddf157379d5ead76f0b8dcdbaa4ec86fdf66751fd4fR225-R254)

### Previews and Tests:
* Updated previews for `SudokuGameScreen` and `KeyPad` to include mock data for `remainingDigitCounts` to ensure the new functionality is visually tested (`feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt`, `feature/game/src/main/java/com/example/feature/game/components/KeyPad.kt`). [[1]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8R378) [[2]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8R403) [[3]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L415-R424) [[4]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8R434) [[5]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R255) [[6]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R277) [[7]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R299) [[8]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R321) [[9]](diffhunk://#diff-09eaf6647652226cd57c5cdfb33e9a5ef053ebce6dbb6824de2113e359300f56R343)

This feature enhances the gameplay experience by providing players with a clear visual representation of the remaining counts for each digit, aiding in strategy and decision-making.