### PR TITLE
Fix: Prevent timer from starting when game is already completed and p…

### DIFF
--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -125,11 +125,12 @@ internal class SudokuGameViewModel(
 				)
 			}
 			loadGame()
+			val loadedGame = game.first()
 			_uiState.update {
 				it.copy(
-					gameState = if (game.value.completed) GameState.VICTORY else GameState.PLAYING,
-					isNewBestTime = if (game.value.completed) {
-						it.currentBestTime == null || it.currentBestTime >= elapsedTime.value
+					gameState = if (loadedGame.completed) GameState.VICTORY else GameState.PLAYING,
+					isNewBestTime = if (loadedGame.completed) {
+						it.currentBestTime == null || it.currentBestTime >= loadedGame.elapsedTime
 					} else {
 						it.isNewBestTime
 					},
@@ -235,7 +236,9 @@ internal class SudokuGameViewModel(
 			}
 
 			is Event.StartTimer -> {
-				elapsedTimerManager.startTracking()
+				if (uiState.value.gameState == GameState.PLAYING) {
+					elapsedTimerManager.startTracking()
+				}
 			}
 		}
 	}
@@ -454,12 +457,13 @@ internal class SudokuGameViewModel(
 						seed = game.value.grid.seed,
 					),
 				)
-				gameManagementUseCases.saveGame(
-					game.value.copy(
+				_game.update {
+					it.copy(
 						completed = true,
 						elapsedTime = elapsedTime.value,
-					),
-				)
+					)
+				}
+				saveGame()
 				operationRepository.clearOperations()
 			}
 		}


### PR DESCRIPTION
…ersist completion state

This commit addresses two issues related to game completion and timer behavior:

1.  **Timer Starting on Completed Game:**
    *   The timer was previously starting even if the game was already completed when the `SudokuGameScreen` was loaded.
    *   **Fix:** In `SudokuGameViewModel`, the `elapsedTimerManager.startTracking()` is now only called if `uiState.value.gameState == GameState.PLAYING`. This ensures the timer doesn't start for an already finished game.

2.  **Game Completion State Not Persisted Correctly:**
    *   When a game was completed, the `completed` flag and `elapsedTime` were updated in a local copy of the game state but not immediately persisted using `saveGame()`. This could lead to the game not being recognized as completed on subsequent loads if the app was closed before the next auto-save.
    *   **Fix:**
        *   When loading a game, the `gameState` and `isNewBestTime` are now determined using `loadedGame` (the game state fetched from the repository) instead of `game.value` (the local Flow's current value). This ensures the initial UI state reflects the persisted completion status.
        *   When a game is won (`onGameWon()`):
            *   The `_game` StateFlow is updated with `completed = true` and the current `elapsedTime`.
            *   `saveGame()` is called immediately to persist this updated game state.