### PR TITLE
Fix: Simplify navigation logic in AppContent

### DIFF
--- a/app/src/main/java/com/example/sudokuslayer/AppContent.kt
+++ b/app/src/main/java/com/example/sudokuslayer/AppContent.kt
@@ -118,9 +118,11 @@ internal fun AppContent(viewModel: AppViewModel = koinViewModel()) {
 			onCloseDrawer = { scope.launch { navigationRailState.collapse() } },
 		)
 		NavDisplay(
-			modifier = Modifier.fillMaxSize().background(
-				MaterialTheme.colorScheme.background,
-			),
+			modifier = Modifier
+				.fillMaxSize()
+				.background(
+					MaterialTheme.colorScheme.background,
+				),
 			backStack = backstack,
 			entryDecorators = listOf(
 				rememberSceneSetupNavEntryDecorator(),
@@ -130,12 +132,10 @@ internal fun AppContent(viewModel: AppViewModel = koinViewModel()) {
 			entryProvider = entryProvider {
 				sudokuCreatorEntry(
 					navigateToGameScreen = {
-						scope.launch {
-							backstack.apply {
-								clear()
-								add(SudokuCreator)
-								add(SudokuGame)
-							}
+						backstack.apply {
+							clear()
+							add(SudokuCreator)
+							add(SudokuGame)
 						}
 					},
 					openDrawer = {
@@ -151,16 +151,15 @@ internal fun AppContent(viewModel: AppViewModel = koinViewModel()) {
 						}
 					},
 					onPlayAgainClick = {
-						scope.launch {
-							backstack.removeLastOrNull()
+						backstack.apply {
+							clear()
+							add(SudokuCreator)
 						}
 					},
 					onNavigateToInsightsClick = {
-						scope.launch {
-							backstack.apply {
-								removeLastOrNull()
-								add(Insights)
-							}
+						backstack.apply {
+							removeLastOrNull()
+							add(Insights)
 						}
 					},
 				)


### PR DESCRIPTION
This commit simplifies the navigation logic within `AppContent.kt` by removing unnecessary `scope.launch` calls when modifying the `backstack`.

The `navigateToGameScreen`, `onPlayAgainClick`, and `onNavigateToInsightsClick` lambdas now directly manipulate the `backstack` without wrapping the operations in a coroutine scope.

Additionally, the `onPlayAgainClick` logic has been updated to clear the backstack and add `SudokuCreator`, ensuring a fresh start when playing again.

Fixes crashes that occur when the backstack is modified too quickly, causing it to become empty.