### PR TITLE
Fix: Use HintLog ID for managing expanded items in HintBottomSheetSca…

### DIFF
--- a/feature/game/src/main/java/com/example/feature/game/components/HintBottomSheetScaffold.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/HintBottomSheetScaffold.kt
@@ -98,7 +98,7 @@ private fun SheetContent(
 	logs: PersistentList<HintLog> = persistentListOf(),
 ) {
 	val listState = rememberLazyListState()
-	val expandedItems = remember { mutableStateListOf<HintLog>() }
+	val expandedItems = remember { mutableStateListOf<Int>() }
 	val interactionSources = remember { mutableStateListOf<MutableInteractionSource>() }
 	val coroutineScope = rememberCoroutineScope()
 
@@ -140,16 +140,16 @@ private fun SheetContent(
 					cardContent = hintLog.structuredExplanation.drop(1).toPersistentList(),
 					onExplainClick = {
 						explainHintClick()
-						if (!expandedItems.contains(hintLog)) {
-							expandedItems.add(hintLog)
+						if (!expandedItems.contains(hintLog.id)) {
+							expandedItems.add(hintLog.id)
 						}
 					},
-					isExpanded = expandedItems.contains(hintLog),
+					isExpanded = expandedItems.contains(hintLog.id),
 					onExpandToggle = {
-						if (expandedItems.contains(hintLog)) {
-							expandedItems.remove(hintLog)
+						if (expandedItems.contains(hintLog.id)) {
+							expandedItems.remove(hintLog.id)
 						} else {
-							expandedItems.add(hintLog)
+							expandedItems.add(hintLog.id)
 						}
 					},
 					onHighlightCellClick = { onHighlightCellClick(hintLog.hint) },


### PR DESCRIPTION
…ffold

This commit modifies the `HintBottomSheetScaffold` to use the `id` of `HintLog` objects instead of the `HintLog` objects themselves for managing the `expandedItems` list.

**Key Changes:**

- **`HintBottomSheetScaffold.kt`:**
    - The `expandedItems` mutable state list is changed from `mutableStateListOf<HintLog>()` to `mutableStateListOf<Int>()`.
    - Logic for adding, removing, and checking for items in `expandedItems` now uses `hintLog.id` instead of the `hintLog` object.

This change ensures that item expansion state is tracked by a stable identifier, which can be beneficial if `HintLog` objects are re-created or if referential equality cannot be guaranteed.