### PR TITLE
Fix/trigger victory on final hint

### DIFF
--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -606,6 +606,7 @@ internal class SudokuGameViewModel(
 					hintLogs = updatedLogs,
 				)
 			}
+			handleAllCellsFilled()
 		}
 	}
 

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -435,6 +435,9 @@ internal class SudokuGameViewModel(
 
 	private fun handleAllCellsFilled() {
 		viewModelScope.launch {
+			if (_game.value.grid.getEmptyCellsCount() != 0) {
+				return@launch
+			}
 			val result = ClassicSudokuSolver.isValidSolution(_game.value.grid)
 			if (result) {
 				_uiState.update {


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `SudokuGameViewModel` class in the `feature/game` module. The changes ensure that the game logic properly handles scenarios where not all cells in the Sudoku grid are filled before validating the solution.

### Enhancements to game logic:

* [`SudokuGameViewModel.kt`](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R438-R440): Updated the `handleAllCellsFilled` method to check if there are any empty cells in the grid before proceeding with solution validation. This prevents unnecessary validation attempts when the grid is incomplete.
* [`SudokuGameViewModel.kt`](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R612): Added a call to `handleAllCellsFilled` within the appropriate coroutine to ensure the method is invoked during the game flow.