### PR TITLE
Feat/redesign difficulty selection

### DIFF
--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
@@ -48,20 +48,18 @@ import com.example.domain.core.SudokuGridSize
 import com.example.feature.creator.SudokuCreatorViewModel.Event
 import com.example.feature.creator.components.ActiveGameCard
 import com.example.feature.creator.components.DifficultySelector
-import com.example.feature.creator.components.HorizontalSelect
+import com.example.feature.creator.components.GridSizeSelector
 import com.example.feature.creator.components.NewGameButton
 import com.example.feature.uicore.theme.LocalPadding
 import com.example.feature.uicore.theme.SudokuSlayerTheme
 import com.example.sudoku.model.SudokuGrid
 import com.example.sudokuslayer.feature.creator.R
-import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.filter
 import org.koin.androidx.compose.koinViewModel
 
 private val PreviewBoxSize = 200.dp
-private const val SELECTS_MAX_WIDTH = 0.8f
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,8 +76,6 @@ internal fun SudokuCreatorScreen(
 		onEvent = viewModel::onEvent,
 		openDrawer = openDrawer,
 		onNavigateToGameScreen = onNavigateToGameScreen,
-		difficultyOptions = viewModel.difficulties,
-		gridSizeOptions = viewModel.gridSizeOptions,
 		modifier = modifier,
 	)
 }
@@ -88,8 +84,6 @@ internal fun SudokuCreatorScreen(
 @Composable
 private fun SudokuCreatorContent(
 	uiState: SudokuCreatorUiState,
-	difficultyOptions: PersistentList<String>,
-	gridSizeOptions: PersistentList<String>,
 	onEvent: (Event) -> Unit,
 	openDrawer: () -> Unit,
 	onNavigateToGameScreen: () -> Unit,
@@ -171,10 +165,11 @@ private fun SudokuCreatorContent(
 			PreviewBox()
 			Spacer(Modifier.height(LocalPadding.current.big))
 
-			Selects(
-				gridSizeOptions = gridSizeOptions,
-				onGridSizeChange = { onEvent(Event.ChangeGridSize(it)) },
-				modifier = Modifier.fillMaxWidth(SELECTS_MAX_WIDTH),
+			GridSizeSelector(
+				options = SudokuGridSize.entries.toPersistentList(),
+				selectedSize = uiState.selectedGridSize,
+				onCheckedChange = { onEvent(Event.ChangeGridSize(it.ordinal)) },
+				modifier = Modifier.padding(LocalPadding.current.small).fillMaxWidth(),
 			)
 			DifficultySelector(
 				options = GameDifficulty.entries.toPersistentList(),
@@ -203,29 +198,12 @@ private fun PreviewBox() {
 	}
 }
 
-@Composable
-private fun Selects(
-	gridSizeOptions: PersistentList<String>,
-	onGridSizeChange: (Int) -> Unit,
-	modifier: Modifier = Modifier,
-) {
-	Column(modifier = modifier) {
-		HorizontalSelect(
-			options = gridSizeOptions,
-			onChange = onGridSizeChange,
-			modifier = Modifier.fillMaxWidth(),
-		)
-	}
-}
-
 @PreviewLightDark
 @Composable
 private fun SudokuCreatorScreenPreview() {
 	SudokuSlayerTheme {
 		SudokuCreatorContent(
 			uiState = SudokuCreatorUiState(),
-			difficultyOptions = persistentListOf("Easy", "Medium", "Hard"),
-			gridSizeOptions = persistentListOf("4x4", "9x9", "16x16"),
 			onEvent = { },
 			openDrawer = { },
 			onNavigateToGameScreen = { },
@@ -252,8 +230,6 @@ private fun SudokuCreatorScreenActiveGamePreview() {
 				savedGame = savedGame,
 				hasActiveGame = true,
 			),
-			difficultyOptions = persistentListOf("Easy", "Medium", "Hard"),
-			gridSizeOptions = persistentListOf("4x4", "9x9", "16x16"),
 			onEvent = { },
 			openDrawer = { },
 			onNavigateToGameScreen = { },
@@ -281,8 +257,6 @@ private fun SudokuCreatorScreenActiveGameExpandedPreview() {
 				hasActiveGame = true,
 				activeGameCardExpanded = true,
 			),
-			difficultyOptions = persistentListOf("Easy", "Medium", "Hard"),
-			gridSizeOptions = persistentListOf("4x4", "9x9", "16x16"),
 			onEvent = { },
 			openDrawer = { },
 			onNavigateToGameScreen = { },

--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
@@ -47,6 +47,7 @@ import com.example.domain.core.GameDifficulty
 import com.example.domain.core.SudokuGridSize
 import com.example.feature.creator.SudokuCreatorViewModel.Event
 import com.example.feature.creator.components.ActiveGameCard
+import com.example.feature.creator.components.DifficultySelector
 import com.example.feature.creator.components.HorizontalSelect
 import com.example.feature.creator.components.NewGameButton
 import com.example.feature.uicore.theme.LocalPadding
@@ -55,6 +56,7 @@ import com.example.sudoku.model.SudokuGrid
 import com.example.sudokuslayer.feature.creator.R
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.filter
 import org.koin.androidx.compose.koinViewModel
 
@@ -171,10 +173,14 @@ private fun SudokuCreatorContent(
 
 			Selects(
 				gridSizeOptions = gridSizeOptions,
-				difficultyOptions = difficultyOptions,
 				onGridSizeChange = { onEvent(Event.ChangeGridSize(it)) },
-				onDifficultyChange = { onEvent(Event.ChangeDifficulty(it)) },
 				modifier = Modifier.fillMaxWidth(SELECTS_MAX_WIDTH),
+			)
+			DifficultySelector(
+				options = GameDifficulty.entries.toPersistentList(),
+				selectedDifficulty = uiState.selectedDifficulty,
+				onCheckedChange = { onEvent(Event.ChangeDifficulty(it.ordinal)) },
+				modifier = Modifier.padding(LocalPadding.current.small).fillMaxWidth(),
 			)
 		}
 	}
@@ -200,20 +206,13 @@ private fun PreviewBox() {
 @Composable
 private fun Selects(
 	gridSizeOptions: PersistentList<String>,
-	difficultyOptions: PersistentList<String>,
 	onGridSizeChange: (Int) -> Unit,
-	onDifficultyChange: (Int) -> Unit,
 	modifier: Modifier = Modifier,
 ) {
 	Column(modifier = modifier) {
 		HorizontalSelect(
 			options = gridSizeOptions,
 			onChange = onGridSizeChange,
-			modifier = Modifier.fillMaxWidth(),
-		)
-		HorizontalSelect(
-			options = difficultyOptions,
-			onChange = onDifficultyChange,
 			modifier = Modifier.fillMaxWidth(),
 		)
 	}

--- a/feature/creator/src/main/java/com/example/feature/creator/components/ActiveGameCard.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/components/ActiveGameCard.kt
@@ -237,8 +237,8 @@ private fun ExpandedContent(
 				}
 			}
 			Spacer(Modifier.height(LocalPadding.current.small))
-			DataRow(stringResource(R.string.difficulty), difficulty.toLocalizedString())
-			DataRow(stringResource(R.string.size), gridSize.toLocalizedString())
+			DataRow(stringResource(R.string.active_difficulty), difficulty.toLocalizedString())
+			DataRow(stringResource(R.string.active_size), gridSize.toLocalizedString())
 			DataRow(stringResource(R.string.time), formattedTime)
 			Spacer(Modifier.height(LocalPadding.current.big))
 			Button(

--- a/feature/creator/src/main/java/com/example/feature/creator/components/DifficultySelector.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/components/DifficultySelector.kt
@@ -17,11 +17,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.domain.core.GameDifficulty
 import com.example.feature.uicore.theme.SudokuSlayerTheme
 import com.example.feature.uicore.toLocalizedString
+import com.example.sudokuslayer.feature.creator.R
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
@@ -36,7 +38,7 @@ internal fun DifficultySelector(
 	val selectedIndex = options.indexOf(selectedDifficulty)
 	Column(modifier) {
 		Text(
-			text = "Difficulty",
+			text = stringResource(R.string.difficulty),
 			style = MaterialTheme.typography.labelLarge,
 		)
 		FlowRow(

--- a/feature/creator/src/main/java/com/example/feature/creator/components/DifficultySelector.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/components/DifficultySelector.kt
@@ -1,0 +1,84 @@
+package com.example.feature.creator.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ButtonGroupDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.ToggleButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.example.domain.core.GameDifficulty
+import com.example.feature.uicore.theme.SudokuSlayerTheme
+import com.example.feature.uicore.toLocalizedString
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun DifficultySelector(
+	options: PersistentList<GameDifficulty>,
+	selectedDifficulty: GameDifficulty,
+	onCheckedChange: (GameDifficulty) -> Unit,
+	modifier: Modifier = Modifier,
+) {
+	val selectedIndex = options.indexOf(selectedDifficulty)
+	Column(modifier) {
+		Text(
+			text = "Difficulty",
+			style = MaterialTheme.typography.labelLarge,
+		)
+		FlowRow(
+			modifier = Modifier.fillMaxWidth(),
+			horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
+			verticalArrangement = Arrangement.spacedBy(2.dp),
+		) {
+			options.forEachIndexed { index, difficulty ->
+				ToggleButton(
+					checked = index == selectedIndex,
+					onCheckedChange = { onCheckedChange(difficulty) },
+					shapes =
+					when (index) {
+						0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
+						options.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+						else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
+					},
+					colors = ToggleButtonDefaults.toggleButtonColors(
+						containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+					),
+				) {
+					Text(difficulty.toLocalizedString())
+				}
+			}
+		}
+	}
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@PreviewLightDark
+@Composable
+internal fun DifficultySelectorPreview() {
+	var selectedDifficulty by remember { mutableStateOf(GameDifficulty.Easy) }
+	SudokuSlayerTheme {
+		Surface(
+			color = MaterialTheme.colorScheme.background,
+		) {
+			DifficultySelector(
+				options = GameDifficulty.entries.toPersistentList(),
+				selectedDifficulty = selectedDifficulty,
+				onCheckedChange = { selectedDifficulty = it },
+			)
+		}
+	}
+}

--- a/feature/creator/src/main/java/com/example/feature/creator/components/GridSizeSelector.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/components/GridSizeSelector.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import com.example.domain.core.GameDifficulty
+import com.example.domain.core.SudokuGridSize
 import com.example.feature.uicore.theme.SudokuSlayerTheme
 import com.example.feature.uicore.toLocalizedString
 import kotlinx.collections.immutable.PersistentList
@@ -27,16 +27,18 @@ import kotlinx.collections.immutable.toPersistentList
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-internal fun DifficultySelector(
-	options: PersistentList<GameDifficulty>,
-	selectedDifficulty: GameDifficulty,
-	onCheckedChange: (GameDifficulty) -> Unit,
+internal fun GridSizeSelector(
+	options: PersistentList<SudokuGridSize>,
+	selectedSize: SudokuGridSize,
+	onCheckedChange: (SudokuGridSize) -> Unit,
 	modifier: Modifier = Modifier,
 ) {
-	val selectedIndex = options.indexOf(selectedDifficulty)
-	Column(modifier) {
+	val selectedIndex = options.indexOf(selectedSize)
+	Column(
+		modifier = modifier,
+	) {
 		Text(
-			text = "Difficulty",
+			text = "Size",
 			style = MaterialTheme.typography.labelLarge,
 		)
 		FlowRow(
@@ -44,10 +46,10 @@ internal fun DifficultySelector(
 			horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
 			verticalArrangement = Arrangement.spacedBy(2.dp),
 		) {
-			options.forEachIndexed { index, difficulty ->
+			options.forEachIndexed { index, size ->
 				ToggleButton(
 					checked = index == selectedIndex,
-					onCheckedChange = { onCheckedChange(difficulty) },
+					onCheckedChange = { onCheckedChange(size) },
 					shapes =
 					when (index) {
 						0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
@@ -58,7 +60,7 @@ internal fun DifficultySelector(
 						containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
 					),
 				) {
-					Text(difficulty.toLocalizedString())
+					Text(size.toLocalizedString())
 				}
 			}
 		}
@@ -68,16 +70,14 @@ internal fun DifficultySelector(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @PreviewLightDark
 @Composable
-private fun DifficultySelectorPreview() {
-	var selectedDifficulty by remember { mutableStateOf(GameDifficulty.Easy) }
+private fun GridSizeSelectorPreview() {
+	var selected by remember { mutableStateOf(SudokuGridSize.NINE) }
 	SudokuSlayerTheme {
-		Surface(
-			color = MaterialTheme.colorScheme.background,
-		) {
-			DifficultySelector(
-				options = GameDifficulty.entries.toPersistentList(),
-				selectedDifficulty = selectedDifficulty,
-				onCheckedChange = { selectedDifficulty = it },
+		Surface {
+			GridSizeSelector(
+				options = SudokuGridSize.entries.toPersistentList(),
+				selectedSize = selected,
+				onCheckedChange = { selected = it },
 			)
 		}
 	}

--- a/feature/creator/src/main/java/com/example/feature/creator/components/GridSizeSelector.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/components/GridSizeSelector.kt
@@ -17,11 +17,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.domain.core.SudokuGridSize
 import com.example.feature.uicore.theme.SudokuSlayerTheme
 import com.example.feature.uicore.toLocalizedString
+import com.example.sudokuslayer.feature.creator.R
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
@@ -38,7 +40,7 @@ internal fun GridSizeSelector(
 		modifier = modifier,
 	) {
 		Text(
-			text = "Size",
+			text = stringResource(R.string.size),
 			style = MaterialTheme.typography.labelLarge,
 		)
 		FlowRow(

--- a/feature/creator/src/main/res/values/strings.xml
+++ b/feature/creator/src/main/res/values/strings.xml
@@ -10,9 +10,11 @@
 	<string name="content_desc_collapse">Collapse</string>
 	<string name="view_board">View Board</string>
 	<string name="continue_button">Continue</string>
-	<string name="difficulty">Difficulty:</string>
-	<string name="size">Size:</string>
+	<string name="active_difficulty">Difficulty:</string>
+	<string name="active_size">Size:</string>
 	<string name="time">Time:</string>
     <string name="new_game_button">New Game</string>
     <string name="content_desc_open_nav_menu">Open navigation menu</string>
+	<string name="size">Size</string>
+	<string name="difficulty">Difficulty</string>
 </resources>


### PR DESCRIPTION
This pull request refactors the `SudokuCreatorScreen` by replacing the combined `Selects` component with two new dedicated components: `GridSizeSelector` and `DifficultySelector`. It also simplifies the codebase and improves maintainability by removing redundant parameters and centralizing logic.

### Component Refactoring:
* Replaced the `Selects` component with two new components: `GridSizeSelector` and `DifficultySelector`, providing a more modular and reusable design. (`feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt` - [[1]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34L172-R178) [[2]](diffhunk://#diff-ae90d6e8b24fcc4ff7e4feb6226e372964fff7985d7cc8a707b8ed93e66d3867R1-R86) [[3]](diffhunk://#diff-3a279c8b7ba486f9741feeaac1259af4b7eb49fc5d2ed19210cdda138d22f5cfR1-R86)

### Code Simplification:
* Removed `difficultyOptions` and `gridSizeOptions` parameters from `SudokuCreatorContent` and its related composables, as these are now derived directly from the domain models (`GameDifficulty` and `SudokuGridSize`). (`feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt` - [[1]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34L79-L80) [[2]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34L89-L90) [[3]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34L256-L257) [[4]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34L285-L286)

### UI Improvements:
* Updated string resources to differentiate between active game attributes and selector labels for better clarity. (`feature/creator/src/main/res/values/strings.xml` - [feature/creator/src/main/res/values/strings.xmlL13-R19](diffhunk://#diff-aafd3039c5ba30cdd99147d647ba33200255d571fd5a707d1833f368f1434eafL13-R19))
* Adjusted the `ActiveGameCard` to use the updated string resources for displaying difficulty and grid size. (`feature/creator/src/main/java/com/example/feature/creator/components/ActiveGameCard.kt` - [feature/creator/src/main/java/com/example/feature/creator/components/ActiveGameCard.ktL240-R241](diffhunk://#diff-db49619fe2b9fe8b81be0586be56f04f0990e2d59051f09cacadcdaaaab403b8L240-R241))