### PR TITLE
Feat/add loading indicator

### DIFF
--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -26,6 +28,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -59,7 +62,6 @@ import com.example.feature.creator.components.preview.BoardPreviewState
 import com.example.feature.creator.components.preview.rememberBoardPreviewState
 import com.example.feature.creator.theme.SudokuCreatorTheme
 import com.example.feature.uicore.theme.LocalPadding
-import com.example.feature.uicore.theme.SudokuSlayerTheme
 import com.example.sudoku.model.SudokuGrid
 import com.example.sudokuslayer.feature.creator.R
 import kotlinx.collections.immutable.persistentListOf
@@ -179,10 +181,12 @@ private fun SudokuCreatorContent(
 								onDifficulyChange = { onEvent(Event.ChangeDifficulty(it)) },
 								sharedTransitionScope = this@SharedTransitionLayout,
 								animatedVisibilityScope = this@AnimatedContent,
-								modifier = Modifier.weight(1f).sharedBounds(
-									rememberSharedContentState("creator_screen_content"),
-									animatedVisibilityScope = this@AnimatedContent,
-								),
+								modifier = Modifier
+									.weight(1f)
+									.sharedBounds(
+										rememberSharedContentState("creator_screen_content"),
+										animatedVisibilityScope = this@AnimatedContent,
+									),
 							)
 						}
 
@@ -191,10 +195,12 @@ private fun SudokuCreatorContent(
 								selectedGridSize = uiState.selectedGridSize,
 								sharedTransitionScope = this@SharedTransitionLayout,
 								animatedVisibilityScope = this@AnimatedContent,
-								modifier = Modifier.weight(1f).sharedBounds(
-									rememberSharedContentState("creator_screen_content"),
-									animatedVisibilityScope = this@AnimatedContent,
-								),
+								modifier = Modifier
+									.weight(1f)
+									.sharedBounds(
+										rememberSharedContentState("creator_screen_content"),
+										animatedVisibilityScope = this@AnimatedContent,
+									),
 							)
 						}
 					}
@@ -280,20 +286,46 @@ private fun LoadingContent(
 	animatedVisibilityScope: AnimatedVisibilityScope,
 	modifier: Modifier = Modifier,
 ) {
-	Box(
-		modifier = modifier.fillMaxSize(),
-		contentAlignment = Alignment.Center,
-	) {
-		with(sharedTransitionScope) {
-			BoardLoadingIndicator(
-				gridSize = selectedGridSize,
+	with(sharedTransitionScope) {
+		Box(
+			modifier = modifier.fillMaxSize(),
+			contentAlignment = Alignment.Center,
+		) {
+			Column(
+				horizontalAlignment = Alignment.CenterHorizontally,
 				modifier = Modifier
-					.size(350.dp)
-					.sharedBounds(
-						rememberSharedContentState("board_preview"),
-						animatedVisibilityScope = animatedVisibilityScope,
-					),
-			)
+					.padding(horizontal = LocalPadding.current.big)
+					.fillMaxWidth(),
+			) {
+
+				BoardLoadingIndicator(
+					gridSize = selectedGridSize,
+					modifier = Modifier
+						.size(300.dp)
+						.sharedBounds(
+							rememberSharedContentState("board_preview"),
+							animatedVisibilityScope = animatedVisibilityScope,
+						),
+				)
+				Spacer(Modifier.size(LocalPadding.current.big))
+
+				Text(
+					text = stringResource(R.string.generating_puzzle),
+					style = MaterialTheme.typography.titleLarge,
+					autoSize = TextAutoSize.StepBased(),
+					maxLines = 1,
+					modifier = Modifier.widthIn(max = 300.dp),
+				)
+				if (selectedGridSize == SudokuGridSize.SIXTEEN) {
+					Spacer(Modifier.size(LocalPadding.current.tiny))
+					Text(
+						text = stringResource(R.string.generating_big_puzzle_info),
+						color = MaterialTheme.colorScheme.onSurfaceVariant,
+						style = MaterialTheme.typography.bodyMedium,
+						modifier = Modifier.widthIn(max = 300.dp),
+					)
+				}
+			}
 		}
 	}
 }
@@ -301,7 +333,7 @@ private fun LoadingContent(
 @PreviewLightDark
 @Composable
 private fun SudokuCreatorScreenPreview() {
-	SudokuSlayerTheme {
+	SudokuCreatorTheme {
 		SudokuCreatorContent(
 			uiState = SudokuCreatorUiState(),
 			onEvent = { },
@@ -324,7 +356,7 @@ private fun SudokuCreatorScreenActiveGamePreview() {
 		completed = false,
 	)
 
-	SudokuSlayerTheme {
+	SudokuCreatorTheme {
 		SudokuCreatorContent(
 			uiState = SudokuCreatorUiState(
 				savedGame = savedGame,
@@ -350,12 +382,43 @@ private fun SudokuCreatorScreenActiveGameExpandedPreview() {
 		completed = false,
 	)
 
-	SudokuSlayerTheme {
+	SudokuCreatorTheme {
 		SudokuCreatorContent(
 			uiState = SudokuCreatorUiState(
 				savedGame = savedGame,
 				hasActiveGame = true,
 				activeGameCardExpanded = true,
+			),
+			onEvent = { },
+			openDrawer = { },
+			onNavigateToGameScreen = { },
+			modifier = Modifier.fillMaxSize(),
+		)
+	}
+}
+
+@PreviewLightDark
+@Composable
+private fun SudokuCreatorScreenLoadingPreview() {
+	SudokuCreatorTheme {
+		SudokuCreatorContent(
+			uiState = SudokuCreatorUiState(loadingState = ScreenState.LOADING),
+			onEvent = { },
+			openDrawer = { },
+			onNavigateToGameScreen = { },
+			modifier = Modifier.fillMaxSize(),
+		)
+	}
+}
+
+@PreviewLightDark
+@Composable
+private fun SudokuCreatorScreenLoadingBigPreview() {
+	SudokuCreatorTheme {
+		SudokuCreatorContent(
+			uiState = SudokuCreatorUiState(
+				loadingState = ScreenState.LOADING,
+				selectedGridSize = SudokuGridSize.SIXTEEN,
 			),
 			onEvent = { },
 			openDrawer = { },

--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
@@ -1,7 +1,11 @@
 package com.example.feature.creator
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.background
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -22,7 +26,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -50,7 +53,9 @@ import com.example.feature.creator.components.ActiveGameCard
 import com.example.feature.creator.components.DifficultySelector
 import com.example.feature.creator.components.GridSizeSelector
 import com.example.feature.creator.components.NewGameButton
+import com.example.feature.creator.components.preview.BoardLoadingIndicator
 import com.example.feature.creator.components.preview.BoardPreview
+import com.example.feature.creator.components.preview.BoardPreviewState
 import com.example.feature.creator.components.preview.rememberBoardPreviewState
 import com.example.feature.creator.theme.SudokuCreatorTheme
 import com.example.feature.uicore.theme.LocalPadding
@@ -85,7 +90,11 @@ internal fun SudokuCreatorScreen(
 	}
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(
+	ExperimentalMaterial3Api::class,
+	ExperimentalMaterial3ExpressiveApi::class,
+	ExperimentalSharedTransitionApi::class,
+)
 @Composable
 private fun SudokuCreatorContent(
 	uiState: SudokuCreatorUiState,
@@ -95,12 +104,6 @@ private fun SudokuCreatorContent(
 	modifier: Modifier = Modifier,
 ) {
 	var gameCreationInProgress by rememberSaveable { mutableStateOf(false) }
-	val hasActiveGame by remember(uiState) {
-		derivedStateOf {
-			uiState.hasActiveGame &&
-				uiState.savedGame != null
-		}
-	}
 
 	if (gameCreationInProgress) {
 		val lifecycle = LocalLifecycleOwner.current.lifecycle
@@ -140,71 +143,158 @@ private fun SudokuCreatorContent(
 		},
 		floatingActionButtonPosition = FabPosition.Center,
 		floatingActionButton = {
-			NewGameButton(
-				modifier = Modifier.fillMaxWidth(0.8f),
-				onClick = {
-					onEvent(Event.NewGame)
-					gameCreationInProgress = true
-				},
-			)
+			AnimatedVisibility(uiState.loadingState == ScreenState.INITIAL) {
+				NewGameButton(
+					modifier = Modifier.fillMaxWidth(0.8f),
+					onClick = {
+						onEvent(Event.NewGame)
+						gameCreationInProgress = true
+					},
+				)
+			}
 		},
 	) { innerPadding ->
 		Column(
-			modifier = Modifier.padding(innerPadding)
+			modifier = Modifier
+				.padding(innerPadding)
 				.fillMaxSize(),
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
-			AnimatedVisibility(visible = hasActiveGame) {
-				ActiveGameCard(
-					isExpanded = uiState.activeGameCardExpanded,
-					difficulty = uiState.savedGame!!.difficulty,
-					gridSize = SudokuGridSize.fromIntSize(uiState.savedGame.grid.gridSize),
-					elapsedTime = uiState.savedGame.elapsedTime,
-					completed = uiState.savedGame.completed,
-					onContinueClick = {
-						onEvent(Event.LoadSudoku)
-						gameCreationInProgress = true
-					},
-					onToggle = { onEvent(Event.ToggleActiveGameCard) },
-					modifier = Modifier.padding(LocalPadding.current.small),
-				)
-			}
-			BoardPreview(
-				modifier = Modifier.size(PreviewBoxSize),
-				state = boardPreviewState,
-			)
-			Spacer(Modifier.height(LocalPadding.current.big))
+			SharedTransitionLayout {
+				AnimatedContent(
+					targetState = uiState.loadingState,
+					label = "SudokuCreatorScreenTransition",
+				) { targetState ->
+					when (targetState) {
+						ScreenState.INITIAL -> {
+							InitialContent(
+								uiState = uiState,
+								boardPreviewState = boardPreviewState,
+								onContinueClick = {
+									onEvent(Event.LoadSudoku)
+									gameCreationInProgress = true
+								},
+								onToggleCardClick = { onEvent(Event.ToggleActiveGameCard) },
+								onGridSizeChange = { onEvent(Event.ChangeGridSize(it)) },
+								onDifficulyChange = { onEvent(Event.ChangeDifficulty(it)) },
+								sharedTransitionScope = this@SharedTransitionLayout,
+								animatedVisibilityScope = this@AnimatedContent,
+								modifier = Modifier.weight(1f).sharedBounds(
+									rememberSharedContentState("creator_screen_content"),
+									animatedVisibilityScope = this@AnimatedContent,
+								),
+							)
+						}
 
-			GridSizeSelector(
-				options = SudokuGridSize.entries.toPersistentList(),
-				selectedSize = uiState.selectedGridSize,
-				onCheckedChange = { onEvent(Event.ChangeGridSize(it)) },
-				modifier = Modifier.padding(LocalPadding.current.small).fillMaxWidth(),
-			)
-			DifficultySelector(
-				options = GameDifficulty.entries.toPersistentList(),
-				selectedDifficulty = uiState.selectedDifficulty,
-				onCheckedChange = { onEvent(Event.ChangeDifficulty(it)) },
-				modifier = Modifier.padding(LocalPadding.current.small).fillMaxWidth(),
-			)
+						ScreenState.LOADING -> {
+							LoadingContent(
+								selectedGridSize = uiState.selectedGridSize,
+								sharedTransitionScope = this@SharedTransitionLayout,
+								animatedVisibilityScope = this@AnimatedContent,
+								modifier = Modifier.weight(1f).sharedBounds(
+									rememberSharedContentState("creator_screen_content"),
+									animatedVisibilityScope = this@AnimatedContent,
+								),
+							)
+						}
+					}
+				}
+			}
 		}
 	}
 }
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-private fun PreviewBox() {
-	Box(
-		contentAlignment = Alignment.Center,
-		modifier =
-		Modifier
-			.size(PreviewBoxSize)
-			.background(color = MaterialTheme.colorScheme.error),
+private fun InitialContent(
+	uiState: SudokuCreatorUiState,
+	boardPreviewState: BoardPreviewState,
+	onContinueClick: () -> Unit,
+	onToggleCardClick: () -> Unit,
+	onGridSizeChange: (SudokuGridSize) -> Unit,
+	onDifficulyChange: (GameDifficulty) -> Unit,
+	sharedTransitionScope: SharedTransitionScope,
+	animatedVisibilityScope: AnimatedVisibilityScope,
+	modifier: Modifier = Modifier,
+) {
+	val hasActiveGame by remember(uiState) {
+		derivedStateOf {
+			uiState.hasActiveGame &&
+				uiState.savedGame != null
+		}
+	}
+
+	Column(
+		modifier = modifier.fillMaxWidth(),
+		horizontalAlignment = Alignment.CenterHorizontally,
 	) {
-		Text(
-			"PREVIEW",
-			style = MaterialTheme.typography.displayMedium,
-			color = MaterialTheme.colorScheme.onError,
+		AnimatedVisibility(visible = hasActiveGame) {
+			ActiveGameCard(
+				isExpanded = uiState.activeGameCardExpanded,
+				difficulty = uiState.savedGame!!.difficulty,
+				gridSize = SudokuGridSize.fromIntSize(uiState.savedGame.grid.gridSize),
+				elapsedTime = uiState.savedGame.elapsedTime,
+				completed = uiState.savedGame.completed,
+				onContinueClick = onContinueClick,
+				onToggle = onToggleCardClick,
+				modifier = Modifier.padding(LocalPadding.current.small),
+			)
+		}
+		with(sharedTransitionScope) {
+			BoardPreview(
+				modifier = Modifier
+					.size(PreviewBoxSize)
+					.sharedBounds(
+						sharedContentState = rememberSharedContentState("board_preview"),
+						animatedVisibilityScope = animatedVisibilityScope,
+					),
+				state = boardPreviewState,
+			)
+		}
+		Spacer(Modifier.height(LocalPadding.current.big))
+
+		GridSizeSelector(
+			options = SudokuGridSize.entries.toPersistentList(),
+			selectedSize = uiState.selectedGridSize,
+			onCheckedChange = onGridSizeChange,
+			modifier = Modifier
+				.padding(LocalPadding.current.small)
+				.fillMaxWidth(),
 		)
+		DifficultySelector(
+			options = GameDifficulty.entries.toPersistentList(),
+			selectedDifficulty = uiState.selectedDifficulty,
+			onCheckedChange = onDifficulyChange,
+			modifier = Modifier
+				.padding(LocalPadding.current.small)
+				.fillMaxWidth(),
+		)
+	}
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+private fun LoadingContent(
+	selectedGridSize: SudokuGridSize,
+	sharedTransitionScope: SharedTransitionScope,
+	animatedVisibilityScope: AnimatedVisibilityScope,
+	modifier: Modifier = Modifier,
+) {
+	Box(
+		modifier = modifier.fillMaxSize(),
+		contentAlignment = Alignment.Center,
+	) {
+		with(sharedTransitionScope) {
+			BoardLoadingIndicator(
+				gridSize = selectedGridSize,
+				modifier = Modifier
+					.size(350.dp)
+					.sharedBounds(
+						rememberSharedContentState("board_preview"),
+						animatedVisibilityScope = animatedVisibilityScope,
+					),
+			)
+		}
 	}
 }
 

--- a/feature/creator/src/main/java/com/example/feature/creator/components/preview/BoardLoadingIndicator.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/components/preview/BoardLoadingIndicator.kt
@@ -1,0 +1,103 @@
+package com.example.feature.creator.components.preview
+
+import androidx.compose.animation.core.InfiniteRepeatableSpec
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.example.domain.core.SudokuGridSize
+import com.example.feature.creator.theme.BoardPreviewColors
+import com.example.feature.creator.theme.LocalBoardPreviewColors
+import com.example.feature.creator.theme.SudokuCreatorTheme
+import kotlin.math.floor
+import kotlin.math.sqrt
+
+@Composable
+internal fun BoardLoadingIndicator(
+	gridSize: SudokuGridSize,
+	modifier: Modifier = Modifier,
+	colors: BoardPreviewColors = LocalBoardPreviewColors.current,
+	animationSpec: InfiniteRepeatableSpec<Float> = infiniteRepeatable(
+		animation = tween(1800, easing = LinearEasing),
+		repeatMode = RepeatMode.Restart,
+	)
+) {
+	val infiniteTransition = rememberInfiniteTransition(label = "game_creation_transition")
+	val waveWidth = 4f
+	val maxDistance = (gridSize.toIntSize() - 1) * 2f
+	val animationStartValue = -(waveWidth / 2f)
+	val animationEndValue = maxDistance + (waveWidth / 2f)
+
+	val waveAnimationValue by infiniteTransition.animateFloat(
+		initialValue = animationStartValue,
+		targetValue = animationEndValue,
+		animationSpec = animationSpec,
+		label = "game_creation_wave_animation",
+	)
+
+	Box(
+		modifier.drawWithContent {
+			val maxWidth = this.size.width
+			val gridSize = gridSize.toIntSize()
+			val cellSize = maxWidth / gridSize
+			val blockSize = floor(sqrt(gridSize.toFloat())).toInt()
+
+			val thinLineWidth = 1.dp.toPx()
+			val thickLineWidth = 2.dp.toPx()
+
+			drawRoundRect(
+				color = colors.background,
+				topLeft = Offset.Zero,
+				size = Size(maxWidth, maxWidth),
+				cornerRadius = CornerRadius(16f, 16f),
+			)
+			drawBoardFrame(
+				color = colors.frame,
+				canvasWidth = maxWidth,
+				strokeWidth = thickLineWidth,
+				cornerRadius = 16f,
+			)
+			drawGridLines(
+				gridSize = gridSize,
+				cellSize = cellSize,
+				blockSize = blockSize,
+				canvasWidth = maxWidth,
+				thinLineWidth = thinLineWidth,
+				thickLineWidth = thickLineWidth,
+				thickLineColor = colors.thickLine,
+				thinLineColor = colors.thinLine,
+			)
+			drawCellIllumination(
+				gridSize = gridSize,
+				cellSize = cellSize,
+				color = colors.frame,
+				progress = waveAnimationValue,
+				waveWidth = waveWidth,
+			)
+		},
+	)
+}
+
+@PreviewLightDark
+@Composable
+private fun BoardLoadingIndicatorPreview() {
+	SudokuCreatorTheme {
+		BoardLoadingIndicator(
+			gridSize = SudokuGridSize.NINE,
+			modifier = Modifier.size(200.dp)
+		)
+	}
+}

--- a/feature/creator/src/main/java/com/example/feature/creator/components/preview/DrawUtilis.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/components/preview/DrawUtilis.kt
@@ -1,5 +1,6 @@
 package com.example.feature.creator.components.preview
 
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -8,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.dp
+import kotlin.math.abs
 
 internal fun DrawScope.drawGridLines(
 	gridSize: Int,
@@ -93,6 +95,43 @@ internal fun DrawScope.drawTransitionSweepEffect(
 			strokeWidth = 1.dp.toPx(),
 			alpha = 0.5f,
 		)
+	}
+}
+
+internal fun DrawScope.drawCellIllumination(
+	gridSize: Int,
+	cellSize: Float,
+	color: Color,
+	progress: Float,
+	waveWidth: Float,
+) {
+	// Loop through all cells to calculate and draw their illumination
+	for (row in 0 until gridSize) {
+		for (col in 0 until gridSize) {
+			// The "distance" of the cell from the top-left corner (row + col)
+			val cellDistance = (row + col).toFloat()
+
+			// How far this cell is from the center of the wave
+			val distanceFromWave = abs(cellDistance - progress)
+
+			// If the cell is within the wave's width, calculate its alpha
+			if (distanceFromWave < waveWidth / 2f) {
+				// Normalize the distance to a value between 0.0 (edge of wave) and 1.0 (center)
+				val normalizedDistance = 1f - (distanceFromWave / (waveWidth / 2f))
+
+				// Use a non-linear easing to make the fade look nicer (fade in fast, fade out slow)
+				val alpha = CubicBezierEasing(0.2f, 0f, 0f, 1f).transform(normalizedDistance) * 0.4f
+
+				if (alpha > 0f) {
+					drawRect(
+						color = color,
+						alpha = alpha,
+						topLeft = Offset(x = col * cellSize, y = row * cellSize),
+						size = Size(cellSize, cellSize)
+					)
+				}
+			}
+		}
 	}
 }
 

--- a/feature/creator/src/main/res/values/strings.xml
+++ b/feature/creator/src/main/res/values/strings.xml
@@ -17,4 +17,6 @@
     <string name="content_desc_open_nav_menu">Open navigation menu</string>
 	<string name="size">Size</string>
 	<string name="difficulty">Difficulty</string>
+    <string name="generating_puzzle">Generating Puzzle…</string>
+	<string name="generating_big_puzzle_info">This is a big one! Generating your 16x16 grid might take a moment.</string>
 </resources>


### PR DESCRIPTION
This pull request introduces significant enhancements to the `SudokuCreatorScreen` in the `feature/creator` module, focusing on implementing shared transitions, improving the loading experience with animations, and adding new components. The changes also include updates to the UI logic, structure, and preview functionality for better user experience and maintainability.

### Enhancements to UI and Transitions:
* Introduced `SharedTransitionLayout` and `AnimatedContent` to enable smooth transitions between different UI states, such as `INITIAL` and `LOADING`. This includes the addition of shared element animations for components like the board preview. (`[[1]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34R3-R8)`, `[[2]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34R148-R235)`, `[[3]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34L164-R336)`)
* Added new composable functions `InitialContent` and `LoadingContent` to modularize and manage UI states, with support for animated visibility and shared transitions. (`[[1]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34R148-R235)`, `[[2]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34L164-R336)`)

### New Component for Loading Animation:
* Created a `BoardLoadingIndicator` component to visually indicate progress during puzzle generation, featuring a wave-like cell illumination animation. (`[feature/creator/src/main/java/com/example/feature/creator/components/preview/BoardLoadingIndicator.ktR1-R103](diffhunk://#diff-087f6467d02c5ab3118cea2a1cdc69411d0c7f683c6f82c7b90d29c167b995d0R1-R103)`)
* Added a utility function `drawCellIllumination` in `DrawUtilis.kt` to handle the rendering of the wave animation across the Sudoku grid. (`[feature/creator/src/main/java/com/example/feature/creator/components/preview/DrawUtilis.ktR101-R137](diffhunk://#diff-a359333fd82992f6c438ed3690d6d89ef608f382857e82a44a29887f8bf4c0abR101-R137)`)

### Updates to UI Logic:
* Refactored logic for determining active game state, moving it from `SudokuCreatorContent` to `InitialContent` for better separation of concerns. (`[feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.ktL98-L103](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34L98-L103)`)
* Enhanced the `NewGameButton` visibility to depend on the `ScreenState.INITIAL` state for better contextual behavior. (`[feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.ktR148-R235](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34R148-R235)`)

### Preview and Theming Improvements:
* Replaced `SudokuSlayerTheme` with `SudokuCreatorTheme` across the screen and previews for consistency. (`[[1]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34L237-R359)`, `[[2]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34L263-R385)`)
* Added new previews for the `LOADING` state, including a specific preview for large grid sizes (16x16). (`[feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.ktR399-R429](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34R399-R429)`)

### Localization and Strings:
* Added new string resources for loading messages, including a special message for large grids. (`[feature/creator/src/main/res/values/strings.xmlR20-R21](diffhunk://#diff-aafd3039c5ba30cdd99147d647ba33200255d571fd5a707d1833f368f1434eafR20-R21)`)