### PR TITLE
Feat/add puzzle seed input

### DIFF
--- a/domain/core/src/main/java/com/example/domain/core/GameDifficulty.kt
+++ b/domain/core/src/main/java/com/example/domain/core/GameDifficulty.kt
@@ -9,25 +9,31 @@ enum class GameDifficulty {
 	Expert,
 }
 
-fun GameDifficulty.toCellsToRemove(gridSize: SudokuGridSize): Int = when (this) {
-	GameDifficulty.Easy -> when (gridSize) {
-		SudokuGridSize.FOUR -> Random.nextInt(2, 4)
-		SudokuGridSize.NINE -> Random.nextInt(30, 40)
-		SudokuGridSize.SIXTEEN -> Random.nextInt(100, 120)
-	}
-	GameDifficulty.Medium -> when (gridSize) {
-		SudokuGridSize.FOUR -> Random.nextInt(4, 6)
-		SudokuGridSize.NINE -> Random.nextInt(41, 50)
-		SudokuGridSize.SIXTEEN -> Random.nextInt(121, 140)
-	}
-	GameDifficulty.Hard -> when (gridSize) {
-		SudokuGridSize.FOUR -> Random.nextInt(6, 8)
-		SudokuGridSize.NINE -> Random.nextInt(51, 60)
-		SudokuGridSize.SIXTEEN -> Random.nextInt(141, 160)
-	}
-	GameDifficulty.Expert -> when (gridSize) {
-		SudokuGridSize.FOUR -> Random.nextInt(8, 10)
-		SudokuGridSize.NINE -> Random.nextInt(61, 64)
-		SudokuGridSize.SIXTEEN -> Random.nextInt(161, 180)
+fun GameDifficulty.toCellsToRemove(gridSize: SudokuGridSize, seed: Long? = null): Int {
+	val random = seed?.let { Random(it) } ?: Random.Default
+	return when (this) {
+		GameDifficulty.Easy -> when (gridSize) {
+			SudokuGridSize.FOUR -> random.nextInt(2, 4)
+			SudokuGridSize.NINE -> random.nextInt(30, 40)
+			SudokuGridSize.SIXTEEN -> random.nextInt(100, 120)
+		}
+
+		GameDifficulty.Medium -> when (gridSize) {
+			SudokuGridSize.FOUR -> random.nextInt(4, 6)
+			SudokuGridSize.NINE -> random.nextInt(41, 50)
+			SudokuGridSize.SIXTEEN -> random.nextInt(121, 140)
+		}
+
+		GameDifficulty.Hard -> when (gridSize) {
+			SudokuGridSize.FOUR -> random.nextInt(6, 8)
+			SudokuGridSize.NINE -> random.nextInt(51, 60)
+			SudokuGridSize.SIXTEEN -> random.nextInt(141, 160)
+		}
+
+		GameDifficulty.Expert -> when (gridSize) {
+			SudokuGridSize.FOUR -> random.nextInt(8, 10)
+			SudokuGridSize.NINE -> random.nextInt(61, 64)
+			SudokuGridSize.SIXTEEN -> random.nextInt(161, 180)
+		}
 	}
 }

--- a/domain/creator/src/main/java/com/example/domain/creator/CreateNewGameUseCase.kt
+++ b/domain/creator/src/main/java/com/example/domain/creator/CreateNewGameUseCase.kt
@@ -10,11 +10,15 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlin.random.Random
 
 class CreateNewGameUseCase(private val operationRepository: OperationRepository) {
-	suspend operator fun invoke(gridSize: SudokuGridSize, difficulty: GameDifficulty): Game {
+	suspend operator fun invoke(
+		gridSize: SudokuGridSize,
+		difficulty: GameDifficulty,
+		seed: Long? = null,
+	): Game {
 		operationRepository.clearOperations()
 		val generator = ClassicSudokuGenerator(gridSize.toIntSize())
-		val cellsToRemove = difficulty.toCellsToRemove(gridSize)
-		val sudokuGrid = generator.createSudoku(cellsToRemove, Random.nextLong())
+		val cellsToRemove = difficulty.toCellsToRemove(gridSize, seed)
+		val sudokuGrid = generator.createSudoku(cellsToRemove, seed ?: Random.nextLong())
 
 		return Game(
 			grid = sudokuGrid,

--- a/domain/creator/src/main/java/com/example/domain/creator/Module.kt
+++ b/domain/creator/src/main/java/com/example/domain/creator/Module.kt
@@ -8,4 +8,5 @@ val domainCreatorModule =
 		factory { GetSavedGameUseCase(get()) }
 		factory { SaveGameUseCase(get()) }
 		factory { HasActiveGameUseCase(get()) }
+		factory { ValidateSeedInputUseCase() }
 	}

--- a/domain/creator/src/main/java/com/example/domain/creator/ValidateSeedInputUseCase.kt
+++ b/domain/creator/src/main/java/com/example/domain/creator/ValidateSeedInputUseCase.kt
@@ -1,0 +1,43 @@
+package com.example.domain.creator
+
+import java.math.BigInteger
+
+class ValidateSeedInputUseCase {
+	companion object {
+		private val MAX_LONG_AS_BIG_INT = BigInteger.valueOf(Long.MAX_VALUE)
+		private val MIN_LONG_AS_BIG_INT = BigInteger.valueOf(Long.MIN_VALUE)
+	}
+
+	data class ValidationResult(val seedText: String, val parsedSeed: Long?)
+
+	operator fun invoke(currentText: String, newText: String): ValidationResult {
+		if (newText.isBlank()) {
+			return ValidationResult(seedText = "", parsedSeed = null)
+		}
+		if (newText == "-") {
+			return ValidationResult(
+				seedText = newText,
+				parsedSeed = null,
+			)
+		}
+		val prospectiveNumber = try {
+			BigInteger(newText)
+		} catch (e: NumberFormatException) {
+			return ValidationResult(
+				seedText = currentText,
+				parsedSeed = null,
+			)
+		}
+		if (prospectiveNumber > MAX_LONG_AS_BIG_INT || prospectiveNumber < MIN_LONG_AS_BIG_INT) {
+			return ValidationResult(
+				seedText = currentText,
+				parsedSeed = null,
+			)
+		}
+
+		return ValidationResult(
+			seedText = newText,
+			parsedSeed = prospectiveNumber.toLong(),
+		)
+	}
+}

--- a/domain/creator/src/test/java/com/example/domain/creator/CreateNewGameUseCaseTest.kt
+++ b/domain/creator/src/test/java/com/example/domain/creator/CreateNewGameUseCaseTest.kt
@@ -1,0 +1,176 @@
+package com.example.domain.creator
+
+import com.example.domain.core.GameDifficulty
+import com.example.domain.core.OperationRepository
+import com.example.domain.core.SudokuGridSize
+import com.example.domain.core.toCellsToRemove
+import com.example.sudoku.generator.ClassicSudokuGenerator
+import com.example.sudoku.model.SudokuGrid
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class CreateNewGameUseCaseTest {
+
+	private lateinit var useCase: CreateNewGameUseCase
+	private lateinit var operationRepository: OperationRepository
+
+	@BeforeEach
+	fun setUp() {
+		operationRepository = mockk(relaxed = true)
+		coEvery { operationRepository.clearOperations() } returns Unit
+		useCase = CreateNewGameUseCase(operationRepository)
+	}
+
+	@AfterEach
+	fun tearDown() {
+		unmockkAll()
+	}
+
+	@Test
+	fun `Test game creation with a specific seed`() = runTest {
+		// Verify that providing a specific seed results in a deterministic Sudoku grid generation.
+		val seed = 12345L
+		val game1 = useCase(SudokuGridSize.NINE, GameDifficulty.Easy, seed)
+		val game2 = useCase(SudokuGridSize.NINE, GameDifficulty.Easy, seed)
+
+		assertEquals(game1.grid, game2.grid)
+	}
+
+	@Test
+	fun `Test game creation with a null seed`() = runTest {
+		// Verify that providing a null seed results in a randomly generated Sudoku grid using Random.nextLong().
+		val game1 = useCase(SudokuGridSize.NINE, GameDifficulty.Easy, null)
+		val game2 = useCase(SudokuGridSize.NINE, GameDifficulty.Easy, null)
+
+		assertNotEquals(game1.grid, game2.grid)
+	}
+
+	@ParameterizedTest
+	@EnumSource(SudokuGridSize::class)
+	fun `Test game creation for each SudokuGridSize`(gridSize: SudokuGridSize) = runTest {
+		// Iterate through all possible SudokuGridSize enum values (e.g., FOUR, NINE, SIXTEEN) and ensure a game is created successfully for each.
+		val game = useCase(gridSize, GameDifficulty.Easy, 1L)
+		assertNotNull(game)
+		assertEquals(gridSize.toIntSize(), game.grid.gridSize)
+	}
+
+	@ParameterizedTest
+	@EnumSource(GameDifficulty::class)
+	fun `Test game creation for each GameDifficulty`(difficulty: GameDifficulty) = runTest {
+		// Iterate through all possible GameDifficulty enum values (e.g., Easy, Medium, Hard, Expert) and ensure a game is created successfully for each.
+		val gridSize = SudokuGridSize.NINE
+		val game = useCase(gridSize, difficulty, 1L)
+		assertNotNull(game)
+		assertEquals(difficulty, game.difficulty)
+	}
+
+	@Test
+	fun `Test  operationRepository clearOperations    is called`() = runTest {
+		// Verify that the `clearOperations` method on the `operationRepository` is invoked exactly once when the use case is executed.
+		useCase(SudokuGridSize.NINE, GameDifficulty.Easy, 1L)
+		coVerify(exactly = 1) { operationRepository.clearOperations() }
+		confirmVerified(operationRepository)
+	}
+
+	@Test
+	fun `Test  difficulty toCellsToRemove    is called with correct gridSize`() = runTest {
+		// Verify that the `toCellsToRemove` method on the `difficulty` object is called with the correct `gridSize`.
+		val gridSize = SudokuGridSize.NINE
+		val seed = 1L
+
+		mockkStatic("com.example.domain.core.GameDifficultyKt")
+		every { GameDifficulty.Easy.toCellsToRemove(gridSize, seed) } returns 30
+
+		useCase(gridSize, GameDifficulty.Easy, 1L)
+
+		verify(exactly = 1) { GameDifficulty.Easy.toCellsToRemove(gridSize, seed) }
+	}
+
+	@Test
+	fun `Test  generator createSudoku    is called with correct parameters  specific seed `() =
+		runTest {
+			// Verify that `createSudoku` on the `generator` is called with the correct `cellsToRemove` and the provided non-null `seed`.
+			val gridSize = SudokuGridSize.NINE
+			val difficulty = GameDifficulty.Easy
+			val seed = 123L
+			val cellsToRemove = difficulty.toCellsToRemove(gridSize, seed)
+			val sudokuGrid = mockk<SudokuGrid>()
+
+			mockkConstructor(ClassicSudokuGenerator::class)
+			val cellsToRemoveSlot = slot<Int>()
+			val seedSlot = slot<Long>()
+			coEvery {
+				anyConstructed<ClassicSudokuGenerator>().createSudoku(
+					capture(cellsToRemoveSlot),
+					capture(seedSlot),
+				)
+			} returns sudokuGrid
+
+			useCase(gridSize, difficulty, seed)
+
+			assertEquals(cellsToRemove, cellsToRemoveSlot.captured)
+			assertEquals(seed, seedSlot.captured)
+		}
+
+	@Test
+	fun `Test  generator createSudoku    is called with correct parameters  null seed `() = runTest {
+		// Verify that `createSudoku` on the `generator` is called with the correct `cellsToRemove` and a Long value when the input `seed` is null.
+		val gridSize = SudokuGridSize.NINE
+		val difficulty = GameDifficulty.Easy
+		val expectedCellsToRemove = 40
+		val sudokuGrid = mockk<SudokuGrid>()
+
+		mockkStatic("com.example.domain.core.GameDifficultyKt")
+		every { difficulty.toCellsToRemove(gridSize, null) } returns expectedCellsToRemove
+
+		mockkConstructor(ClassicSudokuGenerator::class)
+		val cellsToRemoveSlot = slot<Int>()
+		val seedSlot = slot<Long>()
+		coEvery {
+			anyConstructed<ClassicSudokuGenerator>().createSudoku(
+				capture(cellsToRemoveSlot),
+				capture(seedSlot),
+			)
+		} returns sudokuGrid
+
+		useCase(gridSize, difficulty, null)
+
+		assertEquals(expectedCellsToRemove, cellsToRemoveSlot.captured)
+		assertTrue(seedSlot.isCaptured)
+	}
+
+	@Test
+	fun `Test returned Game object properties are initialized correctly`() = runTest {
+		// Verify that the returned `Game` object has its `grid` set to the `sudokuGrid` from the generator, `difficulty` set to the input difficulty,
+		// `elapsedTime` initialized to 0, `hintsUsed` initialized to 0, and `hintLogs` initialized to an empty persistent list.
+		val gridSize = SudokuGridSize.NINE
+		val difficulty = GameDifficulty.Hard
+		val seed = 1L
+
+		val game = useCase(gridSize, difficulty, seed)
+
+		assertNotNull(game.grid)
+		assertEquals(difficulty, game.difficulty)
+		assertEquals(0, game.elapsedTime)
+		assertEquals(0, game.hintsUsed)
+		assertTrue(game.hintLogs.isEmpty())
+	}
+}

--- a/domain/creator/src/test/java/com/example/domain/creator/ValidateSeedInputUseCaseTest.kt
+++ b/domain/creator/src/test/java/com/example/domain/creator/ValidateSeedInputUseCaseTest.kt
@@ -1,0 +1,51 @@
+package com.example.domain.creator
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+
+class ValidateSeedInputUseCaseTest {
+	private val validateSeedInputUseCase = ValidateSeedInputUseCase()
+
+	@Test
+	fun `validateSeedInputUseCase returns empty seedText and null parsedSeed for blank newText`() {
+		val result = validateSeedInputUseCase.invoke("123", "")
+		assertEquals("", result.seedText)
+		assertNull(result.parsedSeed)
+	}
+
+	@Test
+	fun `validateSeedInputUseCase returns newText as seedText and null parsedSeed for newText as dash`() {
+		val result = validateSeedInputUseCase.invoke("123", "-")
+		assertEquals("-", result.seedText)
+		assertNull(result.parsedSeed)
+	}
+
+	@Test
+	fun `validateSeedInputUseCase returns currentText and null parsedSeed for invalid number format`() {
+		val result = validateSeedInputUseCase.invoke("123", "abc")
+		assertEquals("123", result.seedText)
+		assertNull(result.parsedSeed)
+	}
+
+	@Test
+	fun `validateSeedInputUseCase returns currentText and null parsedSeed for number exceeding Long max value`() {
+		val result = validateSeedInputUseCase.invoke("123", "${Long.MAX_VALUE}0")
+		assertEquals("123", result.seedText)
+		assertNull(result.parsedSeed)
+	}
+
+	@Test
+	fun `validateSeedInputUseCase returns currentText and null parsedSeed for number below Long min value`() {
+		val result = validateSeedInputUseCase.invoke("123", "${Long.MIN_VALUE}0")
+		assertEquals("123", result.seedText)
+		assertNull(result.parsedSeed)
+	}
+
+	@Test
+	fun `validateSeedInputUseCase returns newText as seedText and parsedSeed for valid number within Long range`() {
+		val result = validateSeedInputUseCase.invoke("123", "456")
+		assertEquals("456", result.seedText)
+		assertEquals(456L, result.parsedSeed)
+	}
+}

--- a/feature/creator/src/main/java/com/example/feature/creator/Module.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/Module.kt
@@ -13,6 +13,7 @@ val sudokuCreatorModule =
 				getSavedGameUseCase = get(),
 				saveGameUseCase = get(),
 				hasActiveGameUseCase = get(),
+				validateSeedInputUseCase = get(),
 			)
 		}
 	}

--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -47,6 +48,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -241,11 +244,19 @@ private fun InitialContent(
 		}
 	}
 	val lazyColumnState = rememberLazyListState()
+	val focusManager = LocalFocusManager.current
 
 	LazyColumn(
 		state = lazyColumnState,
 		modifier = modifier
-			.fillMaxWidth(),
+			.fillMaxWidth()
+			.pointerInput(Unit) {
+				detectTapGestures(
+					onTap = {
+						focusManager.clearFocus()
+					},
+				)
+			},
 		horizontalAlignment = Alignment.CenterHorizontally,
 	) {
 		item {

--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
@@ -309,9 +309,9 @@ private fun InitialContent(
 		}
 		item {
 			AdvancedOptions(
-				expanded = uiState.advancedOptionsExpanded,
+				expanded = uiState.advancedOptionsState.expanded,
 				onToggle = onToggleAdvancedOptions,
-				seed = uiState.seed?.toString() ?: "",
+				seed = uiState.advancedOptionsState.seedInput,
 				onSeedChange = onSeedChange,
 				modifier = Modifier
 					.padding(LocalPadding.current.small)
@@ -430,7 +430,9 @@ private fun SudokuCreatorScreenActiveGameExpandedPreview() {
 				savedGame = savedGame,
 				hasActiveGame = true,
 				activeGameCardExpanded = true,
-				advancedOptionsExpanded = true,
+				advancedOptionsState = AdvancedOptionsState(
+					expanded = true,
+				),
 			),
 			onEvent = { },
 			openDrawer = { },

--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt
@@ -10,13 +10,17 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
@@ -53,6 +57,7 @@ import com.example.domain.core.GameDifficulty
 import com.example.domain.core.SudokuGridSize
 import com.example.feature.creator.SudokuCreatorViewModel.Event
 import com.example.feature.creator.components.ActiveGameCard
+import com.example.feature.creator.components.AdvancedOptions
 import com.example.feature.creator.components.DifficultySelector
 import com.example.feature.creator.components.GridSizeSelector
 import com.example.feature.creator.components.NewGameButton
@@ -159,6 +164,8 @@ private fun SudokuCreatorContent(
 		Column(
 			modifier = Modifier
 				.padding(innerPadding)
+				.consumeWindowInsets(innerPadding)
+				.imePadding()
 				.fillMaxSize(),
 			horizontalAlignment = Alignment.CenterHorizontally,
 		) {
@@ -179,10 +186,12 @@ private fun SudokuCreatorContent(
 								onToggleCardClick = { onEvent(Event.ToggleActiveGameCard) },
 								onGridSizeChange = { onEvent(Event.ChangeGridSize(it)) },
 								onDifficulyChange = { onEvent(Event.ChangeDifficulty(it)) },
+								onToggleAdvancedOptions = { onEvent(Event.ToggleAdvancedOptions) },
+								onSeedChange = { onEvent(Event.ChangePuzzleSeed(it)) },
 								sharedTransitionScope = this@SharedTransitionLayout,
 								animatedVisibilityScope = this@AnimatedContent,
 								modifier = Modifier
-									.weight(1f)
+									.fillMaxWidth()
 									.sharedBounds(
 										rememberSharedContentState("creator_screen_content"),
 										animatedVisibilityScope = this@AnimatedContent,
@@ -219,6 +228,8 @@ private fun InitialContent(
 	onToggleCardClick: () -> Unit,
 	onGridSizeChange: (SudokuGridSize) -> Unit,
 	onDifficulyChange: (GameDifficulty) -> Unit,
+	onToggleAdvancedOptions: () -> Unit,
+	onSeedChange: (String) -> Unit,
 	sharedTransitionScope: SharedTransitionScope,
 	animatedVisibilityScope: AnimatedVisibilityScope,
 	modifier: Modifier = Modifier,
@@ -229,52 +240,73 @@ private fun InitialContent(
 				uiState.savedGame != null
 		}
 	}
+	val lazyColumnState = rememberLazyListState()
 
-	Column(
-		modifier = modifier.fillMaxWidth(),
+	LazyColumn(
+		state = lazyColumnState,
+		modifier = modifier
+			.fillMaxWidth(),
 		horizontalAlignment = Alignment.CenterHorizontally,
 	) {
-		AnimatedVisibility(visible = hasActiveGame) {
-			ActiveGameCard(
-				isExpanded = uiState.activeGameCardExpanded,
-				difficulty = uiState.savedGame!!.difficulty,
-				gridSize = SudokuGridSize.fromIntSize(uiState.savedGame.grid.gridSize),
-				elapsedTime = uiState.savedGame.elapsedTime,
-				completed = uiState.savedGame.completed,
-				onContinueClick = onContinueClick,
-				onToggle = onToggleCardClick,
-				modifier = Modifier.padding(LocalPadding.current.small),
-			)
+		item {
+			AnimatedVisibility(visible = hasActiveGame) {
+				ActiveGameCard(
+					isExpanded = uiState.activeGameCardExpanded,
+					difficulty = uiState.savedGame!!.difficulty,
+					gridSize = SudokuGridSize.fromIntSize(uiState.savedGame.grid.gridSize),
+					elapsedTime = uiState.savedGame.elapsedTime,
+					completed = uiState.savedGame.completed,
+					onContinueClick = onContinueClick,
+					onToggle = onToggleCardClick,
+					modifier = Modifier.padding(LocalPadding.current.small),
+				)
+			}
 		}
-		with(sharedTransitionScope) {
-			BoardPreview(
+		item {
+			with(sharedTransitionScope) {
+				BoardPreview(
+					modifier = Modifier
+						.size(PreviewBoxSize)
+						.sharedBounds(
+							sharedContentState = rememberSharedContentState("board_preview"),
+							animatedVisibilityScope = animatedVisibilityScope,
+						),
+					state = boardPreviewState,
+				)
+			}
+			Spacer(Modifier.height(LocalPadding.current.big))
+		}
+		item {
+			GridSizeSelector(
+				options = SudokuGridSize.entries.toPersistentList(),
+				selectedSize = uiState.selectedGridSize,
+				onCheckedChange = onGridSizeChange,
 				modifier = Modifier
-					.size(PreviewBoxSize)
-					.sharedBounds(
-						sharedContentState = rememberSharedContentState("board_preview"),
-						animatedVisibilityScope = animatedVisibilityScope,
-					),
-				state = boardPreviewState,
+					.padding(LocalPadding.current.small)
+					.fillMaxWidth(),
 			)
 		}
-		Spacer(Modifier.height(LocalPadding.current.big))
-
-		GridSizeSelector(
-			options = SudokuGridSize.entries.toPersistentList(),
-			selectedSize = uiState.selectedGridSize,
-			onCheckedChange = onGridSizeChange,
-			modifier = Modifier
-				.padding(LocalPadding.current.small)
-				.fillMaxWidth(),
-		)
-		DifficultySelector(
-			options = GameDifficulty.entries.toPersistentList(),
-			selectedDifficulty = uiState.selectedDifficulty,
-			onCheckedChange = onDifficulyChange,
-			modifier = Modifier
-				.padding(LocalPadding.current.small)
-				.fillMaxWidth(),
-		)
+		item {
+			DifficultySelector(
+				options = GameDifficulty.entries.toPersistentList(),
+				selectedDifficulty = uiState.selectedDifficulty,
+				onCheckedChange = onDifficulyChange,
+				modifier = Modifier
+					.padding(LocalPadding.current.small)
+					.fillMaxWidth(),
+			)
+		}
+		item {
+			AdvancedOptions(
+				expanded = uiState.advancedOptionsExpanded,
+				onToggle = onToggleAdvancedOptions,
+				seed = uiState.seed?.toString() ?: "",
+				onSeedChange = onSeedChange,
+				modifier = Modifier
+					.padding(LocalPadding.current.small)
+					.fillMaxWidth(),
+			)
+		}
 	}
 }
 
@@ -297,7 +329,6 @@ private fun LoadingContent(
 					.padding(horizontal = LocalPadding.current.big)
 					.fillMaxWidth(),
 			) {
-
 				BoardLoadingIndicator(
 					gridSize = selectedGridSize,
 					modifier = Modifier
@@ -388,6 +419,7 @@ private fun SudokuCreatorScreenActiveGameExpandedPreview() {
 				savedGame = savedGame,
 				hasActiveGame = true,
 				activeGameCardExpanded = true,
+				advancedOptionsExpanded = true,
 			),
 			onEvent = { },
 			openDrawer = { },

--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
@@ -133,6 +133,7 @@ internal class SudokuCreatorViewModel(
 				createNewGameUseCase(
 					_uiState.value.selectedGridSize,
 					_uiState.value.selectedDifficulty,
+					_uiState.value.seed,
 				)
 			saveGameUseCase(newGame)
 

--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
@@ -11,13 +11,13 @@ import com.example.domain.creator.CreateNewGameUseCase
 import com.example.domain.creator.GetSavedGameUseCase
 import com.example.domain.creator.HasActiveGameUseCase
 import com.example.domain.creator.SaveGameUseCase
+import com.example.domain.creator.ValidateSeedInputUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.math.BigInteger
 
 @Stable
 @Immutable
@@ -28,8 +28,14 @@ internal data class SudokuCreatorUiState(
 	val savedGame: Game? = null,
 	val hasActiveGame: Boolean = false,
 	val activeGameCardExpanded: Boolean = false,
-	val advancedOptionsExpanded: Boolean = false,
-	val seed: Long? = null,
+	val advancedOptionsState: AdvancedOptionsState = AdvancedOptionsState(),
+)
+
+@Immutable
+internal data class AdvancedOptionsState(
+	val expanded: Boolean = false,
+	val seedInput: String = "",
+	val parsedSeed: Long? = null,
 )
 
 @Stable
@@ -43,6 +49,7 @@ internal class SudokuCreatorViewModel(
 	private val getSavedGameUseCase: GetSavedGameUseCase,
 	private val saveGameUseCase: SaveGameUseCase,
 	private val hasActiveGameUseCase: HasActiveGameUseCase,
+	private val validateSeedInputUseCase: ValidateSeedInputUseCase,
 ) : ViewModel() {
 	private val _uiState = MutableStateFlow(SudokuCreatorUiState())
 	val uiState: StateFlow<SudokuCreatorUiState> = _uiState.asStateFlow()
@@ -69,6 +76,7 @@ internal class SudokuCreatorViewModel(
 	}
 
 	sealed interface Event {
+
 		data class ChangeDifficulty(val difficulty: GameDifficulty) : Event
 
 		data class ChangeGridSize(val size: SudokuGridSize) : Event
@@ -80,7 +88,6 @@ internal class SudokuCreatorViewModel(
 		data object ToggleActiveGameCard : Event
 
 		data object ToggleAdvancedOptions : Event
-
 		data class ChangePuzzleSeed(val seed: String) : Event
 	}
 
@@ -133,7 +140,7 @@ internal class SudokuCreatorViewModel(
 				createNewGameUseCase(
 					_uiState.value.selectedGridSize,
 					_uiState.value.selectedDifficulty,
-					_uiState.value.seed,
+					_uiState.value.advancedOptionsState.parsedSeed,
 				)
 			saveGameUseCase(newGame)
 
@@ -151,42 +158,33 @@ internal class SudokuCreatorViewModel(
 	}
 
 	private fun toggleAdvancedOptions() {
-		_uiState.update {
-			it.copy(advancedOptionsExpanded = !it.advancedOptionsExpanded)
+		_uiState.updateAdvancedOptions {
+			it.copy(expanded = !it.expanded)
 		}
 	}
 
 	private fun handleChangePuzzleSeed(input: String) {
 		viewModelScope.launch {
-			val filteredInput = input.filter { it.isDigit() }
-			if (filteredInput.isBlank()) {
-				_uiState.update {
-					it.copy(
-						seed = null,
-					)
-				}
-				return@launch
-			}
-			try {
-				val inputAsBigInt = BigInteger(filteredInput)
-				val maxLongAsBigInt = BigInteger.valueOf(Long.MAX_VALUE)
-
-				if (inputAsBigInt > maxLongAsBigInt) {
-					return@launch
-				} else {
-					_uiState.update {
-						it.copy(
-							seed = inputAsBigInt.toLong(),
-						)
-					}
-				}
-			} catch (e: NumberFormatException) {
-				_uiState.update {
-					it.copy(
-						seed = null,
-					)
-				}
+			val result = validateSeedInputUseCase(
+				currentText = uiState.value.advancedOptionsState.seedInput,
+				newText = input,
+			)
+			_uiState.updateAdvancedOptions {
+				it.copy(
+					seedInput = result.seedText,
+					parsedSeed = result.parsedSeed,
+				)
 			}
 		}
+	}
+}
+
+private inline fun MutableStateFlow<SudokuCreatorUiState>.updateAdvancedOptions(
+	function: (AdvancedOptionsState) -> AdvancedOptionsState,
+) {
+	update { state ->
+		state.copy(
+			advancedOptionsState = function(state.advancedOptionsState),
+		)
 	}
 }

--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.math.BigInteger
 
 @Stable
 @Immutable
@@ -27,6 +28,8 @@ internal data class SudokuCreatorUiState(
 	val savedGame: Game? = null,
 	val hasActiveGame: Boolean = false,
 	val activeGameCardExpanded: Boolean = false,
+	val advancedOptionsExpanded: Boolean = false,
+	val seed: Long? = null,
 )
 
 @Stable
@@ -75,6 +78,10 @@ internal class SudokuCreatorViewModel(
 		data object LoadSudoku : Event
 
 		data object ToggleActiveGameCard : Event
+
+		data object ToggleAdvancedOptions : Event
+
+		data class ChangePuzzleSeed(val seed: String) : Event
 	}
 
 	fun onEvent(event: Event) {
@@ -84,6 +91,8 @@ internal class SudokuCreatorViewModel(
 			is Event.NewGame -> handleNewGame()
 			is Event.LoadSudoku -> handleLoadGame()
 			is Event.ToggleActiveGameCard -> toggleActiveGameCard()
+			is Event.ToggleAdvancedOptions -> toggleAdvancedOptions()
+			is Event.ChangePuzzleSeed -> handleChangePuzzleSeed(event.seed)
 		}
 	}
 
@@ -137,6 +146,46 @@ internal class SudokuCreatorViewModel(
 
 	private fun handleLoadGame() {
 		viewModelScope.launch {
+		}
+	}
+
+	private fun toggleAdvancedOptions() {
+		_uiState.update {
+			it.copy(advancedOptionsExpanded = !it.advancedOptionsExpanded)
+		}
+	}
+
+	private fun handleChangePuzzleSeed(input: String) {
+		viewModelScope.launch {
+			val filteredInput = input.filter { it.isDigit() }
+			if (filteredInput.isBlank()) {
+				_uiState.update {
+					it.copy(
+						seed = null,
+					)
+				}
+				return@launch
+			}
+			try {
+				val inputAsBigInt = BigInteger(filteredInput)
+				val maxLongAsBigInt = BigInteger.valueOf(Long.MAX_VALUE)
+
+				if (inputAsBigInt > maxLongAsBigInt) {
+					return@launch
+				} else {
+					_uiState.update {
+						it.copy(
+							seed = inputAsBigInt.toLong(),
+						)
+					}
+				}
+			} catch (e: NumberFormatException) {
+				_uiState.update {
+					it.copy(
+						seed = null,
+					)
+				}
+			}
 		}
 	}
 }

--- a/feature/creator/src/main/java/com/example/feature/creator/components/AdvancedOptions.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/components/AdvancedOptions.kt
@@ -1,0 +1,157 @@
+package com.example.feature.creator.components
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.example.feature.creator.theme.SudokuCreatorTheme
+import com.example.feature.uicore.theme.LocalPadding
+import com.example.sudokuslayer.feature.creator.R
+
+@Composable
+internal fun AdvancedOptions(
+	expanded: Boolean,
+	onToggle: () -> Unit,
+	seed: String,
+	onSeedChange: (String) -> Unit,
+	modifier: Modifier = Modifier,
+) {
+	Column(
+		modifier = modifier
+			.background(
+				color = MaterialTheme.colorScheme.surfaceContainer,
+				shape = MaterialTheme.shapes.small,
+			),
+	) {
+		Row(
+			modifier = Modifier
+				.fillMaxWidth()
+				.clickable {
+					onToggle()
+				}
+				.padding(
+					horizontal = LocalPadding.current.small,
+					vertical = LocalPadding.current.tiny,
+				),
+			verticalAlignment = Alignment.CenterVertically,
+		) {
+			Icon(
+				Icons.Default.Settings,
+				contentDescription = null,
+				tint = MaterialTheme.colorScheme.onSurface,
+			)
+			Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+			Text(
+				text = stringResource(R.string.advanced_options),
+				color = MaterialTheme.colorScheme.onSurface,
+			)
+			Spacer(Modifier.weight(1f))
+			IconButton(onClick = onToggle) {
+				AnimatedContent(expanded) { targetState ->
+					if (targetState) {
+						Icon(
+							Icons.Default.KeyboardArrowUp,
+							contentDescription = stringResource(R.string.content_desc_collapse),
+							tint = MaterialTheme.colorScheme.onSurface,
+						)
+					} else {
+						Icon(
+							Icons.Default.KeyboardArrowDown,
+							contentDescription = stringResource(R.string.content_desc_expand),
+							tint = MaterialTheme.colorScheme.onSurface,
+						)
+					}
+				}
+			}
+		}
+		AnimatedVisibility(expanded) {
+			Column(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(horizontal = LocalPadding.current.small)
+					.padding(top = LocalPadding.current.tiny, bottom = LocalPadding.current.normal),
+				verticalArrangement = Arrangement.spacedBy(LocalPadding.current.tiny),
+			) {
+				OutlinedTextField(
+					label = { Text(stringResource(R.string.puzzle_seed)) },
+					placeholder = { Text(stringResource(R.string.puzzle_seed_placeholder)) },
+					value = seed,
+					onValueChange = onSeedChange,
+					keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+					singleLine = true,
+					supportingText = {
+						Text(
+							text = stringResource(R.string.puzzle_seed_supporting_text),
+							style = MaterialTheme.typography.bodySmall,
+							color = MaterialTheme.colorScheme.onSurfaceVariant,
+						)
+					},
+					trailingIcon = {
+						if (seed.isNotBlank()) {
+							IconButton(onClick = { onSeedChange("") }) {
+								Icon(
+									Icons.Default.Clear,
+									contentDescription = stringResource(R.string.clear_puzzle_seed_content_desc),
+								)
+							}
+						}
+					},
+					modifier = Modifier.fillMaxWidth(),
+				)
+			}
+		}
+	}
+}
+
+@PreviewLightDark
+@Composable
+private fun AdvancedOptionsExpandedPreview() {
+	SudokuCreatorTheme {
+		AdvancedOptions(
+			expanded = true,
+			onToggle = { },
+			seed = "",
+			onSeedChange = { },
+			Modifier.fillMaxWidth(),
+		)
+	}
+}
+
+@PreviewLightDark
+@Composable
+private fun AdvancedOptionsCollapsedPreview() {
+	SudokuCreatorTheme {
+		AdvancedOptions(
+			expanded = false,
+			onToggle = { },
+			seed = "",
+			onSeedChange = { },
+			Modifier.fillMaxWidth(),
+		)
+	}
+}

--- a/feature/creator/src/main/res/values/strings.xml
+++ b/feature/creator/src/main/res/values/strings.xml
@@ -19,4 +19,9 @@
 	<string name="difficulty">Difficulty</string>
     <string name="generating_puzzle">Generating Puzzle…</string>
 	<string name="generating_big_puzzle_info">This is a big one! Generating your 16x16 grid might take a moment.</string>
+    <string name="puzzle_seed">Puzzle Seed</string>
+	<string name="puzzle_seed_placeholder">Leave blank for a random puzzle</string>
+	<string name="puzzle_seed_supporting_text">The seed is a number used to generate a unique puzzle. Use the same seed on another device to play the exact same game.</string>
+	<string name="clear_puzzle_seed_content_desc">Clear Puzzle Seed</string>
+	<string name="advanced_options">Advanced Options</string>
 </resources>

--- a/sudoku-core/src/main/java/com/example/sudoku/generator/ClassicSudokuGenerator.kt
+++ b/sudoku-core/src/main/java/com/example/sudoku/generator/ClassicSudokuGenerator.kt
@@ -71,21 +71,6 @@ class ClassicSudokuGenerator(private val gridSize: Int = 9) : SudokuGenerator {
 			}
 			i += j
 		}
-// 		for (index in cellIndices) {
-// 			if (removedCount >= cellsToRemove) break
-//
-// 			val row = index / gridSize
-// 			val col = index % gridSize
-// 			val originalValue = removedGrid.getCellAt(row, col).number
-//
-// 			removedGrid = removedGrid.withValue(row, col, 0)
-//
-// 			if (!ClassicSudokuSolver.hasUniqueSolution(removedGrid)) {
-// 				removedGrid = removedGrid.withValue(row, col, originalValue)
-// 			} else {
-// 				removedCount++
-// 			}
-// 		}
 
 		return removedGrid
 	}


### PR DESCRIPTION
This pull request introduces functionality for deterministic Sudoku puzzle generation using an optional seed, along with UI enhancements to support advanced options for seed input. The changes span across the core logic, use case, and UI layers, with corresponding test coverage added to ensure correctness.

### Core Logic Enhancements:
* Updated `GameDifficulty.toCellsToRemove` to accept an optional seed for deterministic random number generation. If no seed is provided, the default random generator is used. (`domain/core/src/main/java/com/example/domain/core/GameDifficulty.kt`, [domain/core/src/main/java/com/example/domain/core/GameDifficulty.ktL12-R37](diffhunk://#diff-e0f301459d415951fe15b577f9bbfda73b931dd975018e1de10f908d077a8f60L12-R37))

### Use Case Updates:
* Modified `CreateNewGameUseCase` to accept a seed parameter, passing it to both `toCellsToRemove` and the Sudoku generator for deterministic puzzle creation. (`domain/creator/src/main/java/com/example/domain/creator/CreateNewGameUseCase.kt`, [domain/creator/src/main/java/com/example/domain/creator/CreateNewGameUseCase.ktL13-R21](diffhunk://#diff-155b13e101c1504b12afbba8aa61fc5d0efe424a2324ff49b4d8267193c0ac2cL13-R21))

### Test Coverage:
* Added comprehensive tests in `CreateNewGameUseCaseTest` to verify behavior with specific seeds, null seeds, and various grid sizes and difficulties. Tests also validate the correct invocation of repository and generator methods. (`domain/creator/src/test/java/com/example/domain/creator/CreateNewGameUseCaseTest.kt`, [domain/creator/src/test/java/com/example/domain/creator/CreateNewGameUseCaseTest.ktR1-R176](diffhunk://#diff-afac7b738f127a7dcee0591adbb6c63d385a03a324cf18bd44505ec2772b8273R1-R176))

### UI Enhancements:
* Introduced an "Advanced Options" section in the `SudokuCreatorScreen` to allow users to toggle advanced settings and input a custom seed. This includes updates to the layout (`LazyColumn` for better scrolling), focus management, and event handling for seed changes. (`feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorScreen.kt`, [[1]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34R9-R24) [[2]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34R170-R171) [[3]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34R310-R321)
* Updated `SudokuCreatorViewModel` to handle advanced options toggle and seed input validation, ensuring the seed is a valid `Long` or null. (`feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt`, [[1]](diffhunk://#diff-cfa326546dde72bd16fb765399b53c63aa1b4a17412fe3d430e7c19d7afd9908R31-R32) [[2]](diffhunk://#diff-cfa326546dde72bd16fb765399b53c63aa1b4a17412fe3d430e7c19d7afd9908R81-R84) [[3]](diffhunk://#diff-cfa326546dde72bd16fb765399b53c63aa1b4a17412fe3d430e7c19d7afd9908R152-R191)

### Summary of Changes:
#### Core Logic:
* Added support for deterministic random number generation in `GameDifficulty.toCellsToRemove` by introducing an optional seed parameter.

#### Use Case:
* Enhanced `CreateNewGameUseCase` to propagate the seed parameter for deterministic Sudoku generation.

#### Testing:
* Added tests for deterministic and non-deterministic Sudoku generation, grid size and difficulty handling, and repository/generator interactions in `CreateNewGameUseCaseTest`.

#### UI Enhancements:
* Added "Advanced Options" to `SudokuCreatorScreen` for seed input and toggling additional settings. [[1]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34R9-R24) [[2]](diffhunk://#diff-518e2c2498d4ad50a40a7e2f5e145cf64188b6ad0be5702323eeb5aea1f86b34R310-R321)
* Improved focus management and layout with `LazyColumn` and tap gesture detection in `SudokuCreatorScreen`.

#### ViewModel Updates:
* Implemented logic for toggling advanced options and validating seed input in `SudokuCreatorViewModel`. [[1]](diffhunk://#diff-cfa326546dde72bd16fb765399b53c63aa1b4a17412fe3d430e7c19d7afd9908R31-R32) [[2]](diffhunk://#diff-cfa326546dde72bd16fb765399b53c63aa1b4a17412fe3d430e7c19d7afd9908R152-R191)