### PR TITLE
Feat: Add "Play Again" functionality to Insights screen

### DIFF
--- a/app/src/main/java/com/example/sudokuslayer/AppContent.kt
+++ b/app/src/main/java/com/example/sudokuslayer/AppContent.kt
@@ -30,6 +30,7 @@ import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.rememberSceneSetupNavEntryDecorator
 import com.example.domain.settings.models.ColorScheme
 import com.example.domain.settings.models.DarkMode
+import com.example.feature.creator.PuzzlePreset
 import com.example.feature.creator.SudokuCreator
 import com.example.feature.creator.sudokuCreatorEntry
 import com.example.feature.game.SudokuGame
@@ -63,14 +64,14 @@ class MyApplication : Application() {
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun AppContent(viewModel: AppViewModel = koinViewModel()) {
-	val backstack = rememberNavBackStack<Destination>(SudokuCreator)
+	val backstack = rememberNavBackStack<Destination>(SudokuCreator())
 	val navigationRailState = rememberWideNavigationRailState(
 		initialValue = WideNavigationRailValue.Collapsed,
 	)
 	val destinations =
 		persistentListOf(
 			SudokuGame,
-			SudokuCreator,
+			SudokuCreator(),
 			Insights,
 			Settings,
 		)
@@ -134,7 +135,7 @@ internal fun AppContent(viewModel: AppViewModel = koinViewModel()) {
 					navigateToGameScreen = {
 						backstack.apply {
 							clear()
-							add(SudokuCreator)
+							add(SudokuCreator())
 							add(SudokuGame)
 						}
 					},
@@ -153,7 +154,7 @@ internal fun AppContent(viewModel: AppViewModel = koinViewModel()) {
 					onPlayAgainClick = {
 						backstack.apply {
 							clear()
-							add(SudokuCreator)
+							add(SudokuCreator())
 						}
 					},
 					onNavigateToInsightsClick = {
@@ -167,9 +168,12 @@ internal fun AppContent(viewModel: AppViewModel = koinViewModel()) {
 					onNavigateToGameScreen = {
 						backstack.apply {
 							clear()
-							add(SudokuCreator)
+							add(SudokuCreator())
 							add(SudokuGame)
 						}
+					},
+					onNavigateToCreator = { seed, gridSize, difficulty ->
+						backstack.add(SudokuCreator(PuzzlePreset(seed, difficulty, gridSize)))
 					},
 					openDrawer = {
 						scope.launch {

--- a/domain/core/build.gradle.kts
+++ b/domain/core/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
 dependencies {
 	api(projects.sudokuCore)
 	implementation(libs.kotlinx.datetime)
+	implementation(libs.kotlinx.serialization.json)
 }

--- a/domain/core/build.gradle.kts
+++ b/domain/core/build.gradle.kts
@@ -5,5 +5,4 @@ plugins {
 dependencies {
 	api(projects.sudokuCore)
 	implementation(libs.kotlinx.datetime)
-	implementation(libs.kotlinx.serialization.json)
 }

--- a/feature/creator/src/main/java/com/example/feature/creator/CreatorRoute.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/CreatorRoute.kt
@@ -7,14 +7,17 @@ import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.EntryProviderBuilder
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entry
+import com.example.domain.core.GameDifficulty
+import com.example.domain.core.SudokuGridSize
 import com.example.feature.uicore.navigation.AppIcon
 import com.example.feature.uicore.navigation.Destination
 import com.example.sudokuslayer.feature.creator.R
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
 
 @Serializable
-data object SudokuCreator : Destination {
+data class SudokuCreator(val args: PuzzlePreset? = null) : Destination {
 	override val routeId: String = "sudoku_creator"
 	override val displayNameRes: Int = R.string.sudoku_creator_title
 	override val icon: AppIcon = AppIcon.VectorIcon(Icons.Default.Add)
@@ -25,7 +28,9 @@ fun EntryProviderBuilder<NavKey>.sudokuCreatorEntry(
 	openDrawer: () -> Unit,
 ) {
 	entry<SudokuCreator> {
-		val viewModel = koinViewModel<SudokuCreatorViewModel>()
+		val viewModel = koinViewModel<SudokuCreatorViewModel> {
+			parametersOf(it.args)
+		}
 		SudokuCreatorScreen(
 			onNavigateToGameScreen = navigateToGameScreen,
 			openDrawer = openDrawer,
@@ -34,3 +39,10 @@ fun EntryProviderBuilder<NavKey>.sudokuCreatorEntry(
 		)
 	}
 }
+
+@Serializable
+data class PuzzlePreset(
+	val seed: Long,
+	val difficulty: GameDifficulty,
+	val gridSize: SudokuGridSize,
+)

--- a/feature/creator/src/main/java/com/example/feature/creator/Module.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/Module.kt
@@ -7,13 +7,14 @@ import org.koin.dsl.module
 val sudokuCreatorModule =
 	module {
 		includes(domainCreatorModule)
-		viewModel {
+		viewModel { parameters ->
 			SudokuCreatorViewModel(
 				createNewGameUseCase = get(),
 				getSavedGameUseCase = get(),
 				saveGameUseCase = get(),
 				hasActiveGameUseCase = get(),
 				validateSeedInputUseCase = get(),
+				args = parameters.getOrNull(),
 			)
 		}
 	}

--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
@@ -45,7 +45,7 @@ internal enum class ScreenState {
 }
 
 internal class SudokuCreatorViewModel(
-	private val args: PuzzlePreset? = null,
+	args: PuzzlePreset? = null,
 	private val createNewGameUseCase: CreateNewGameUseCase,
 	private val getSavedGameUseCase: GetSavedGameUseCase,
 	private val saveGameUseCase: SaveGameUseCase,

--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
@@ -74,19 +74,17 @@ internal class SudokuCreatorViewModel(
 				}
 			}
 		}
-		viewModelScope.launch {
-			args?.let { parameters ->
-				_uiState.update {
-					it.copy(
-						selectedDifficulty = parameters.difficulty,
-						selectedGridSize = parameters.gridSize,
-						advancedOptionsState = it.advancedOptionsState.copy(
-							expanded = true,
-							seedInput = parameters.seed.toString(),
-							parsedSeed = parameters.seed,
-						),
-					)
-				}
+		args?.let { parameters ->
+			_uiState.update {
+				it.copy(
+					selectedDifficulty = parameters.difficulty,
+					selectedGridSize = parameters.gridSize,
+					advancedOptionsState = it.advancedOptionsState.copy(
+						expanded = true,
+						seedInput = parameters.seed.toString(),
+						parsedSeed = parameters.seed,
+					),
+				)
 			}
 		}
 	}

--- a/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/SudokuCreatorViewModel.kt
@@ -45,6 +45,7 @@ internal enum class ScreenState {
 }
 
 internal class SudokuCreatorViewModel(
+	private val args: PuzzlePreset? = null,
 	private val createNewGameUseCase: CreateNewGameUseCase,
 	private val getSavedGameUseCase: GetSavedGameUseCase,
 	private val saveGameUseCase: SaveGameUseCase,
@@ -69,6 +70,21 @@ internal class SudokuCreatorViewModel(
 				_uiState.update {
 					it.copy(
 						hasActiveGame = hasActiveGame,
+					)
+				}
+			}
+		}
+		viewModelScope.launch {
+			args?.let { parameters ->
+				_uiState.update {
+					it.copy(
+						selectedDifficulty = parameters.difficulty,
+						selectedGridSize = parameters.gridSize,
+						advancedOptionsState = it.advancedOptionsState.copy(
+							expanded = true,
+							seedInput = parameters.seed.toString(),
+							parsedSeed = parameters.seed,
+						),
 					)
 				}
 			}

--- a/feature/statistics/src/main/java/com/example/feature/statistics/StatisticsRoute.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/StatisticsRoute.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.EntryProviderBuilder
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entry
+import com.example.domain.core.GameDifficulty
+import com.example.domain.core.SudokuGridSize
 import com.example.feature.statistics.insights.InsightsScreen
 import com.example.feature.uicore.navigation.AppIcon
 import com.example.feature.uicore.navigation.Destination
@@ -24,6 +26,7 @@ data object Insights : Destination {
 fun EntryProviderBuilder<NavKey>.insightsEntry(
 	openDrawer: () -> Unit,
 	onNavigateToGameScreen: () -> Unit,
+	onNavigateToCreator: (Long, SudokuGridSize, GameDifficulty) -> Unit,
 ) {
 	entry<Insights> {
 		val viewModel = koinViewModel<StatisticsViewModel>()
@@ -31,6 +34,7 @@ fun EntryProviderBuilder<NavKey>.insightsEntry(
 			viewModel = viewModel,
 			openDrawer = openDrawer,
 			onNavigateToGameScreen = onNavigateToGameScreen,
+			onNavigateToCreator = onNavigateToCreator,
 			modifier = Modifier
 				.fillMaxSize(),
 		)

--- a/feature/statistics/src/main/java/com/example/feature/statistics/StatisticsViewModel.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/StatisticsViewModel.kt
@@ -124,7 +124,6 @@ internal class StatisticsViewModel(
 		data class ToggleColumnVisibility(val column: InsightsTableColumn) : StatisticsEvent
 		data class ReorderColumns(val from: Int, val to: Int) : StatisticsEvent
 		data class ColumnHeaderClicked(val column: InsightsTableColumn) : StatisticsEvent
-		data class PlayGameClicked(val gameSeed: Long) : StatisticsEvent
 		data object ClearData : StatisticsEvent
 		data object PlayFirstGame : StatisticsEvent
 
@@ -163,16 +162,12 @@ internal class StatisticsViewModel(
 				event.value,
 			)
 
-			is StatisticsEvent.PlayGameClicked -> handlePlayGameClicked(event.gameSeed)
 			is StatisticsEvent.ClearFilters -> clearFilters()
 			is StatisticsEvent.ClearData -> clearData()
 			is StatisticsEvent.PlayFirstGame -> handlePlayFirstGame()
 		}
 	}
 
-	private fun handlePlayGameClicked(gameSeed: Long) {
-		// TODO
-	}
 
 	private fun loadInitialData() {
 		viewModelScope.launch {

--- a/feature/statistics/src/main/java/com/example/feature/statistics/insights/InsightsScreen.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/insights/InsightsScreen.kt
@@ -76,6 +76,7 @@ import org.koin.androidx.compose.koinViewModel
 @Composable
 internal fun InsightsScreen(
 	onNavigateToGameScreen: () -> Unit,
+	onNavigateToCreator: (Long, SudokuGridSize, GameDifficulty) -> Unit,
 	openDrawer: () -> Unit,
 	modifier: Modifier = Modifier,
 	viewModel: StatisticsViewModel = koinViewModel<StatisticsViewModel>(),
@@ -98,6 +99,7 @@ internal fun InsightsScreen(
 		activeFilterCount = activeFilterCount,
 		onEvent = viewModel::onEvent,
 		onNavigateToGameScreen = onNavigateToGameScreen,
+		onNavigateToCreator = onNavigateToCreator,
 		openDrawer = openDrawer,
 		onCopySeedClick = {
 			coroutineScope.launch {
@@ -128,6 +130,7 @@ private fun InsightsScreenContent(
 	onEvent: (StatisticsEvent) -> Unit,
 	openDrawer: () -> Unit,
 	onNavigateToGameScreen: () -> Unit,
+	onNavigateToCreator: (Long, SudokuGridSize, GameDifficulty) -> Unit,
 	onCopySeedClick: (Long) -> Unit,
 	modifier: Modifier = Modifier,
 ) {
@@ -289,6 +292,7 @@ private fun InsightsScreenContent(
 								)
 							}
 						},
+						onNavigateToCreator = onNavigateToCreator,
 						modifier = Modifier.fillMaxSize(),
 					)
 				}
@@ -349,6 +353,7 @@ private fun InsightsScreenPreview() {
 			openDrawer = { },
 			onCopySeedClick = { },
 			onNavigateToGameScreen = { },
+			onNavigateToCreator = { _, _, _ -> },
 			modifier = Modifier.fillMaxSize(),
 		)
 	}

--- a/feature/statistics/src/main/java/com/example/feature/statistics/insights/SuccessContent.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/insights/SuccessContent.kt
@@ -29,7 +29,6 @@ import com.example.domain.core.SudokuGridSize
 import com.example.feature.statistics.InsightsUiState
 import com.example.feature.statistics.StatisticsViewModel
 import com.example.feature.statistics.StatisticsViewModel.StatisticsEvent.ColumnHeaderClicked
-import com.example.feature.statistics.StatisticsViewModel.StatisticsEvent.PlayGameClicked
 import com.example.feature.statistics.insights.components.CompactSummaryLayout
 import com.example.feature.statistics.insights.components.ExpandedSummaryLayout
 import com.example.feature.statistics.insights.components.insightsTableContent

--- a/feature/statistics/src/main/java/com/example/feature/statistics/insights/SuccessContent.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/insights/SuccessContent.kt
@@ -52,6 +52,7 @@ internal fun SuccessContent(
 	tableColumnsState: PersistentList<ColumnDisplayState>,
 	onEvent: (StatisticsViewModel.StatisticsEvent) -> Unit,
 	onCopySeedClick: (Long) -> Unit,
+	onNavigateToCreator: (Long, SudokuGridSize, GameDifficulty) -> Unit,
 	modifier: Modifier = Modifier,
 ) {
 	val formattedTimeSpent = rememberFormattedTime(uiState.totalTimeSpent.toFloat())
@@ -130,7 +131,7 @@ internal fun SuccessContent(
 				sortState = uiState.sortState,
 				visibleColumns = visibleColumns,
 				scrollState = horizontalScrollState,
-				onPlayClick = { onEvent(PlayGameClicked(it)) },
+				onPlayClick = { seed, size, difficulty -> onNavigateToCreator(seed, size, difficulty) },
 				onCopySeedClick = onCopySeedClick,
 				onColumnHeaderClick = { column ->
 					onEvent(
@@ -168,5 +169,6 @@ private fun SuccessContentPreview() {
 		tableColumnsState = tableColumnsState,
 		onEvent = {},
 		onCopySeedClick = {},
+		onNavigateToCreator = { _, _, _ -> },
 	)
 }

--- a/feature/statistics/src/main/java/com/example/feature/statistics/insights/components/InsightsTable.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/insights/components/InsightsTable.kt
@@ -53,7 +53,7 @@ internal fun InsightsTable(
 	tableColumnsState: PersistentList<ColumnDisplayState>,
 	sortState: SortState,
 	onColumnHeaderClick: (InsightsTableColumn) -> Unit,
-	onPlayClick: (Long) -> Unit,
+	onPlayClick: (Long, SudokuGridSize, GameDifficulty) -> Unit,
 	modifier: Modifier = Modifier,
 ) {
 	val scrollState = rememberScrollState()
@@ -127,7 +127,7 @@ internal fun LazyListScope.insightsTableContent(
 	scrollState: ScrollState,
 	onColumnHeaderClick: (InsightsTableColumn) -> Unit,
 	onCopySeedClick: (Long) -> Unit,
-	onPlayClick: (Long) -> Unit,
+	onPlayClick: (Long, SudokuGridSize, GameDifficulty) -> Unit,
 	modifier: Modifier = Modifier,
 ) {
 	item {
@@ -168,7 +168,7 @@ private fun InsightsTablePreview() {
 						.toPersistentList(),
 					sortState = SortState(InsightsTableColumn.Date, SortDirection.DESC),
 					onColumnHeaderClick = { },
-					onPlayClick = { },
+					onPlayClick = { _, _, _ -> },
 				)
 			}
 		}

--- a/feature/statistics/src/main/java/com/example/feature/statistics/insights/components/TableRow.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/insights/components/TableRow.kt
@@ -48,7 +48,7 @@ internal fun TableRow(
 	visibleColumns: PersistentList<InsightsTableColumn>,
 	scrollStateProvider: () -> ScrollState,
 	onCopySeedClick: (Long) -> Unit,
-	onPlayClick: (Long) -> Unit,
+	onPlayClick: (Long, SudokuGridSize, GameDifficulty) -> Unit,
 	modifier: Modifier = Modifier,
 ) {
 	Row(
@@ -66,7 +66,7 @@ internal fun TableRow(
 		) {
 			gameResult.seed?.let {
 				IconButton(
-					onClick = { onPlayClick(it) },
+					onClick = { onPlayClick(it, gameResult.gridSize, gameResult.difficulty) },
 				) {
 					Icon(
 						Icons.Default.PlayArrow,
@@ -177,7 +177,7 @@ private fun TableRowPreview() {
 				visibleColumns = InsightsTableColumn.ALL.toPersistentList(),
 				scrollStateProvider = { scrollState },
 				onCopySeedClick = { },
-				onPlayClick = { },
+				onPlayClick = { _, _, _ -> },
 			)
 		}
 	}


### PR DESCRIPTION
This commit introduces the ability to start a new game with the same seed, difficulty, and grid size directly from the game statistics (Insights) screen.

**Key Changes:**

*   **Navigation & Data Passing:**
    *   `SudokuCreator` destination in `CreatorRoute.kt` now accepts an optional `PuzzlePreset` serializable argument. This allows passing seed, difficulty, and grid size when navigating to the creator screen.
    *   `PuzzlePreset` data class created to encapsulate these parameters.
    *   `InsightsRoute.kt` and `InsightsScreen.kt` now have an `onNavigateToCreator` callback that takes `seed`, `gridSize`, and `difficulty`.
    *   `AppContent.kt` updated to handle this new navigation: when `onNavigateToCreator` is invoked from Insights, it navigates to `SudokuCreator` with the provided `PuzzlePreset`.
*   **Insights Screen UI & Logic:**
    *   `InsightsTable.kt` and `TableRow.kt`: The "play" icon/button in the game history table now calls `onNavigateToCreator` (via `onPlayClick`) with the game's seed, grid size, and difficulty.
    *   `SuccessContent.kt`: The `onPlayClick` callback within the table is wired to `onNavigateToCreator`.
*   **Sudoku Creator ViewModel:**
    *   `SudokuCreatorViewModel.kt` now accepts an optional `PuzzlePreset` in its constructor via Koin parameters.
    *   If `PuzzlePreset` arguments are provided, the ViewModel initializes its state (`selectedDifficulty`, `selectedGridSize`, and `advancedOptionsState` for seed) with these preset values.
*   **Dependency Injection:**
    *   `feature/creator/Module.kt`: `SudokuCreatorViewModel` factory updated to allow passing `parameters.getOrNull()` for the `args` constructor parameter.
*   **Dependencies:**
    *   `domain/core/build.gradle.kts`: Added `kotlinx-serialization-json` dependency.