### PR TITLE
Fix/game state initialization

### DIFF
--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameScreen.kt
@@ -97,7 +97,7 @@ internal fun SudokuGameScreen(
 @Composable
 private fun SudokuGameScreenContent(
 	uiState: SudokuGameUiState,
-	game: Game,
+	game: Game?,
 	remainingDigitCounts: PersistentMap<Int, Int>,
 	onEvent: (Event) -> Unit,
 	elapsedTime: () -> Long,
@@ -130,65 +130,12 @@ private fun SudokuGameScreenContent(
 		}
 	}
 
-	VictoryDialog(
-		dialogState = victoryDialogState,
-		timeSpent = elapsedTime(),
-		difficulty = game.difficulty,
-		gridSize = SudokuGridSize.fromIntSize(game.grid.gridSize),
-		hintsUsed = game.hintsUsed,
-		bestTime = uiState.currentBestTime,
-		isNewBest = uiState.isNewBestTime,
-		onDismissRequest = {
-			victoryDialogState.visible = false
-		},
-	)
-
-	ResetDialog(
-		isVisible = resetDialogState,
-		onConfirmClick = {
-			onEvent(Event.ResetGame)
-			onEvent(Event.ResetNotes)
-			resetDialogState = false
-		},
-		onDismissClick = { resetDialogState = false },
-		onClearNotesClick = {
-			onEvent(Event.ResetNotes)
-			resetDialogState = false
-		},
-	)
-
-	HintsDialog(
-		isVisible = hintsDialogState,
-		onDismissRequest = { hintsDialogState = false },
-		onHintClick = {
-			onEvent(Event.ProvideHint)
-			hintsDialogState = false
-			scope.launch {
-				scaffoldState.bottomSheetState.expand()
-			}
-		},
-		onFillNotesClick = {
-			onEvent(Event.HintFillNotes)
-			hintsDialogState = false
-		},
-		onFindMistakesClick = {
-			onEvent(Event.FindMistakes)
-			hintsDialogState = false
-		},
-		onShowLogsClick = {
-			hintsDialogState = false
-			scope.launch {
-				scaffoldState.bottomSheetState.expand()
-			}
-		},
-	)
-
 	HintBottomSheetScaffold(
 		modifier = modifier,
 		sheetScaffoldState = scaffoldState,
 		snackbarState = uiState.snackbarState,
-		hintLogs = game.hintLogs,
-		showNextHint = game.hintLogs.lastOrNull()?.isRevealed ?: true,
+		hintLogs = game?.hintLogs ?: persistentListOf(),
+		showNextHint = game?.hintLogs?.lastOrNull()?.isRevealed ?: true,
 		explainHintClick = { onEvent(Event.ExplainHint) },
 		nextHintClick = { onEvent(Event.ProvideHint) },
 		onHighlightCellClick = { onEvent(Event.HighlightHintCells(it)) },
@@ -204,7 +151,7 @@ private fun SudokuGameScreenContent(
 			)
 		},
 	) { innerPadding ->
-		if (uiState.gameState == GameState.LOADING) {
+		if (uiState.gameState == GameState.LOADING || game == null) {
 			Box(
 				contentAlignment = Alignment.Center,
 				modifier = Modifier.fillMaxSize(),
@@ -212,6 +159,74 @@ private fun SudokuGameScreenContent(
 				CircularWavyProgressIndicator()
 			}
 		} else {
+			VictoryDialog(
+				dialogState = victoryDialogState,
+				timeSpent = elapsedTime(),
+				difficulty = game.difficulty,
+				gridSize = SudokuGridSize.fromIntSize(game.grid.gridSize),
+				hintsUsed = game.hintsUsed,
+				bestTime = uiState.currentBestTime,
+				isNewBest = uiState.isNewBestTime,
+				onDismissRequest = {
+					victoryDialogState.visible = false
+				},
+			)
+
+			ResetDialog(
+				isVisible = resetDialogState,
+				onConfirmClick = {
+					onEvent(Event.ResetGame)
+					onEvent(Event.ResetNotes)
+					resetDialogState = false
+				},
+				onDismissClick = { resetDialogState = false },
+				onClearNotesClick = {
+					onEvent(Event.ResetNotes)
+					resetDialogState = false
+				},
+			)
+
+			HintsDialog(
+				isVisible = hintsDialogState,
+				onDismissRequest = { hintsDialogState = false },
+				onHintClick = {
+					onEvent(Event.ProvideHint)
+					hintsDialogState = false
+					scope.launch {
+						scaffoldState.bottomSheetState.expand()
+					}
+				},
+				onFillNotesClick = {
+					onEvent(Event.HintFillNotes)
+					hintsDialogState = false
+				},
+				onFindMistakesClick = {
+					onEvent(Event.FindMistakes)
+					hintsDialogState = false
+				},
+				onShowLogsClick = {
+					hintsDialogState = false
+					scope.launch {
+						scaffoldState.bottomSheetState.expand()
+					}
+				},
+			)
+			val actions: @Composable (Modifier) -> Unit = {
+				GameActions(
+					gameState = uiState.gameState,
+					remainingDigitCounts = remainingDigitCounts,
+					uiState = uiState,
+					gridSize = game.grid.gridSize,
+					summaryOpen = victoryDialogState.visible,
+					onEvent = onEvent,
+					onHintClick = { hintsDialogState = true },
+					onResetClick = { resetDialogState = true },
+					onPlayAgainClick = onPlayAgainClick,
+					onNavigateToInsightsClick = onNavigateToInsightsClick,
+					onViewSummary = { victoryDialogState.visible = true },
+					modifier = it,
+				)
+			}
 			if (isPortrait) {
 				Column(
 					modifier =
@@ -224,47 +239,11 @@ private fun SudokuGameScreenContent(
 						focusedCells = uiState.focusedCells,
 						onCellClick = { row, col -> onEvent(Event.SelectCell(row, col)) },
 						onCellLongClick = { row, col -> onEvent(Event.CellLongClick(row, col)) },
-						modifier = Modifier.weight(1f).aspectRatio(1f),
+						modifier = Modifier
+							.weight(1f)
+							.aspectRatio(1f),
 					)
-					AnimatedContent(
-						targetState = uiState.gameState,
-						contentAlignment = Alignment.Center,
-						modifier = Modifier.weight(1f),
-					) { state ->
-						when (state) {
-							GameState.LOADING -> {}
-							GameState.PLAYING -> {
-								KeyPad(
-									remainingDigitCounts = remainingDigitCounts,
-									onNumberClick = { onEvent(Event.InputNumber(it)) },
-									onNumberLongClick = { onEvent(Event.LongInputNumber(it)) },
-									onClearClick = { onEvent(Event.ClearCell) },
-									onUndoClick = { onEvent(Event.Undo) },
-									onRedoClick = { onEvent(Event.Redo) },
-									onHintClick = { hintsDialogState = true },
-									onResetClick = { resetDialogState = true },
-									onSwitchInputMode = { onEvent(Event.SwitchInputMode(it)) },
-									noteMode = uiState.isInNoteMode,
-									gridSize = game.grid.gridSize,
-									isLeftHandMode = uiState.isLeftHandMode,
-									showActionButtonsOnTop = uiState.showActionButtonsOnTop,
-									modifier = Modifier.weight(1f),
-								)
-							}
-
-							GameState.VICTORY -> {
-								PostGameActions(
-									onViewSummary = {
-										victoryDialogState.visible = true
-									},
-									onPlayAgainClick = onPlayAgainClick,
-									onShowInsights = onNavigateToInsightsClick,
-									summaryOpen = victoryDialogState.visible,
-									modifier = Modifier.weight(1f),
-								)
-							}
-						}
-					}
+					actions(Modifier.weight(1f))
 				}
 			} else {
 				Row(
@@ -277,48 +256,66 @@ private fun SudokuGameScreenContent(
 						focusedCells = uiState.focusedCells,
 						onCellClick = { row, col -> onEvent(Event.SelectCell(row, col)) },
 						onCellLongClick = { row, col -> onEvent(Event.CellLongClick(row, col)) },
-						modifier = Modifier.weight(1f).aspectRatio(1f),
+						modifier = Modifier
+							.weight(1f)
+							.aspectRatio(1f),
 					)
-					AnimatedContent(
-						targetState = uiState.gameState,
-						modifier = Modifier.weight(0.8f),
-						contentAlignment = Alignment.Center,
-					) { state ->
-						when (state) {
-							GameState.LOADING -> {}
-							GameState.PLAYING -> {
-								KeyPad(
-									remainingDigitCounts = remainingDigitCounts,
-									onNumberClick = { onEvent(Event.InputNumber(it)) },
-									onNumberLongClick = { onEvent(Event.LongInputNumber(it)) },
-									onClearClick = { onEvent(Event.ClearCell) },
-									onUndoClick = { onEvent(Event.Undo) },
-									onRedoClick = { onEvent(Event.Redo) },
-									onHintClick = { hintsDialogState = true },
-									onResetClick = { resetDialogState = true },
-									onSwitchInputMode = { onEvent(Event.SwitchInputMode(it)) },
-									noteMode = uiState.isInNoteMode,
-									gridSize = game.grid.gridSize,
-									isLeftHandMode = uiState.isLeftHandMode,
-									showActionButtonsOnTop = uiState.showActionButtonsOnTop,
-									modifier = Modifier.weight(1f).fillMaxHeight(),
-								)
-							}
-
-							GameState.VICTORY -> {
-								PostGameActions(
-									onViewSummary = {
-										victoryDialogState.visible = true
-									},
-									onPlayAgainClick = onPlayAgainClick,
-									onShowInsights = onNavigateToInsightsClick,
-									summaryOpen = victoryDialogState.visible,
-									modifier = Modifier.weight(1f).fillMaxHeight(),
-								)
-							}
-						}
-					}
+					actions(Modifier.weight(1f))
 				}
+			}
+		}
+	}
+}
+
+@Composable
+private fun GameActions(
+	gameState: GameState,
+	remainingDigitCounts: PersistentMap<Int, Int>,
+	uiState: SudokuGameUiState,
+	gridSize: Int,
+	summaryOpen: Boolean,
+	onEvent: (Event) -> Unit,
+	onHintClick: () -> Unit,
+	onResetClick: () -> Unit,
+	onPlayAgainClick: () -> Unit,
+	onNavigateToInsightsClick: () -> Unit,
+	onViewSummary: () -> Unit,
+	modifier: Modifier = Modifier,
+) {
+	AnimatedContent(
+		targetState = gameState,
+		modifier = modifier,
+		contentAlignment = Alignment.Center,
+	) { state ->
+		when (state) {
+			GameState.LOADING -> Unit
+			GameState.PLAYING -> {
+				KeyPad(
+					remainingDigitCounts = remainingDigitCounts,
+					onNumberClick = { onEvent(Event.InputNumber(it)) },
+					onNumberLongClick = { onEvent(Event.LongInputNumber(it)) },
+					onClearClick = { onEvent(Event.ClearCell) },
+					onUndoClick = { onEvent(Event.Undo) },
+					onRedoClick = { onEvent(Event.Redo) },
+					onHintClick = onHintClick,
+					onResetClick = onResetClick,
+					onSwitchInputMode = { onEvent(Event.SwitchInputMode(it)) },
+					noteMode = uiState.isInNoteMode,
+					gridSize = gridSize,
+					isLeftHandMode = uiState.isLeftHandMode,
+					showActionButtonsOnTop = uiState.showActionButtonsOnTop,
+				)
+			}
+
+			GameState.VICTORY -> {
+				PostGameActions(
+					onViewSummary = onViewSummary,
+					onPlayAgainClick = onPlayAgainClick,
+					onShowInsights = onNavigateToInsightsClick,
+					summaryOpen = summaryOpen,
+					modifier = Modifier
+						.fillMaxHeight(),
+				)
 			}
 		}
 	}

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.domain.core.Game
-import com.example.domain.core.GameDifficulty
 import com.example.domain.core.GameResult
 import com.example.domain.core.HintLog
 import com.example.domain.core.OperationRepository
@@ -25,7 +24,6 @@ import com.example.feature.game.model.SnackbarState
 import com.example.feature.game.model.SudokuGameUiState
 import com.example.feature.game.util.AndroidHintStringProvider
 import com.example.sudoku.model.CellAttributes
-import com.example.sudoku.model.SolutionGrid
 import com.example.sudoku.model.SudokuGrid
 import com.example.sudoku.model.clearAllCornerNotes
 import com.example.sudoku.model.fillNotes
@@ -49,6 +47,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -84,18 +83,10 @@ internal class SudokuGameViewModel(
 	val uiState: StateFlow<SudokuGameUiState> = _uiState
 	private var hintFocusJob: Job? = null
 
-	val game: StateFlow<Game> = gameManagementUseCases.getGame().stateIn(
+	val game: StateFlow<Game?> = gameManagementUseCases.getGame().stateIn(
 		scope = viewModelScope,
 		started = SharingStarted.WhileSubscribed(5000L),
-		initialValue = Game(
-			grid = SudokuGrid(),
-			difficulty = GameDifficulty.Easy,
-			elapsedTime = 0L,
-			hintsUsed = 0,
-			hintLogs = persistentListOf(),
-			completed = false,
-			solution = SolutionGrid(intArrayOf(), 0),
-		),
+		initialValue = null,
 	)
 	val elapsedTime =
 		elapsedTimerManager.elapsedTime.stateIn(
@@ -107,7 +98,7 @@ internal class SudokuGameViewModel(
 		game,
 		settingsRepository.remainingDigitCounts,
 	) { game, showRemainingDigitCounts ->
-		if (showRemainingDigitCounts) {
+		if (showRemainingDigitCounts && game != null) {
 			calculateRemainingCounts(game.grid).toPersistentMap()
 		} else {
 			persistentMapOf()
@@ -234,22 +225,26 @@ internal class SudokuGameViewModel(
 	}
 
 	private suspend fun saveGame() {
-		gameManagementUseCases.saveGame(
-			game.value.copy(
-				elapsedTime = elapsedTime.value,
-			),
-		)
+		game.value?.let { currentGame ->
+			gameManagementUseCases.saveGame(
+				currentGame.copy(
+					elapsedTime = elapsedTime.value,
+				),
+			)
+		}
 	}
 
 	private suspend inline fun updateGame(transform: (Game) -> Game) {
 		updateGameMutex.withLock {
-			gameManagementUseCases.saveGame(transform(game.value))
+			game.value?.let { currentGame ->
+				gameManagementUseCases.saveGame(transform(currentGame))
+			}
 		}
 	}
 
 	private fun observeGameState() {
 		viewModelScope.launch {
-			game.distinctUntilChangedBy(Game::toStateKey)
+			game.filterNotNull().distinctUntilChangedBy(Game::toStateKey)
 				.collect { g ->
 					val bestTime = getBestTimeUseCase(
 						g.difficulty,
@@ -350,11 +345,13 @@ internal class SudokuGameViewModel(
 		val lastHint = _uiState.value.lastHint
 		val isCorrectGuess =
 			lastHint != null && lastHint.row == row && lastHint.col == column && lastHint.value == number
+
+		val hintLogs = game.value?.hintLogs
 		if (!isCorrectGuess) {
-			return game.value.hintLogs
+			return hintLogs ?: persistentListOf()
 		}
 
-		val updatedLogs = game.value.hintLogs.toMutableList()
+		val updatedLogs = hintLogs?.toMutableList() ?: mutableListOf()
 		val hintLogIndex =
 			updatedLogs.indexOfLast {
 				it.hint.row == lastHint.row &&
@@ -394,39 +391,41 @@ internal class SudokuGameViewModel(
 
 	private fun handleAllCellsFilled() {
 		viewModelScope.launch {
-			if (game.value.grid.getEmptyCellsCount() != 0) {
-				return@launch
-			}
-			val result = ClassicSudokuSolver.isValidSolution(game.value.grid)
-			if (result) {
-				_uiState.update {
-					it.copy(
-						gameState = GameState.VICTORY,
-						isNewBestTime = it.currentBestTime == null || it.currentBestTime >= elapsedTime.value,
-						focusedCells = persistentSetOf(),
-					)
+			game.value?.let { currentGame ->
+				if (currentGame.grid.getEmptyCellsCount() != 0) {
+					return@launch
 				}
-				elapsedTimerManager.stopTracking()
-				val gridSize = SudokuGridSize.fromIntSize(game.value.grid.gridSize)
-				gameResultWriter.saveGameResult(
-					GameResult(
-						timeInSeconds = elapsedTime.value,
-						difficulty = game.value.difficulty,
-						gridSize = gridSize,
-						hintsUsed = game.value.hintsUsed,
-						completionDate = System.now().toLocalDateTime(
-							TimeZone.currentSystemDefault(),
+				val result = ClassicSudokuSolver.isValidSolution(currentGame.grid)
+				if (result) {
+					_uiState.update {
+						it.copy(
+							gameState = GameState.VICTORY,
+							isNewBestTime = it.currentBestTime == null || it.currentBestTime >= elapsedTime.value,
+							focusedCells = persistentSetOf(),
+						)
+					}
+					elapsedTimerManager.stopTracking()
+					val gridSize = SudokuGridSize.fromIntSize(currentGame.grid.gridSize)
+					gameResultWriter.saveGameResult(
+						GameResult(
+							timeInSeconds = elapsedTime.value,
+							difficulty = currentGame.difficulty,
+							gridSize = gridSize,
+							hintsUsed = currentGame.hintsUsed,
+							completionDate = System.now().toLocalDateTime(
+								TimeZone.currentSystemDefault(),
+							),
+							seed = currentGame.grid.seed,
 						),
-						seed = game.value.grid.seed,
-					),
-				)
-				updateGame {
-					it.copy(
-						completed = true,
-						elapsedTime = elapsedTime.value,
 					)
+					updateGame {
+						it.copy(
+							completed = true,
+							elapsedTime = elapsedTime.value,
+						)
+					}
+					operationRepository.clearOperations()
 				}
-				operationRepository.clearOperations()
 			}
 		}
 	}
@@ -465,37 +464,39 @@ internal class SudokuGameViewModel(
 	private fun provideHint() {
 		viewModelScope.launch {
 			if (_uiState.value.gameState == GameState.VICTORY) return@launch
-			game.value.hintLogs.lastOrNull()?.isRevealed?.let { if (!it) return@launch }
+			game.value?.let { g ->
+				g.hintLogs.lastOrNull()?.isRevealed?.let { if (!it) return@launch }
+				val hint: Hint? = hintUseCases.provideHint(g)
 
-			val hint: Hint? = hintUseCases.provideHint(game.value)
-			updateGame { currentGame ->
-				if (hint != null) {
-					val grid = gameManagementUseCases.selectCell(
-						sudoku = currentGame.grid,
-						selectedCell = hint.row to hint.col,
-					)
-					hintFocus(hint)
-					val hintLog =
-						hintUseCases.generateLog(
-							id = game.value.hintLogs.size,
-							hint = hint,
+				updateGame { currentGame ->
+					if (hint != null) {
+						val grid = gameManagementUseCases.selectCell(
+							sudoku = currentGame.grid,
+							selectedCell = hint.row to hint.col,
+						)
+						hintFocus(hint)
+						val hintLog =
+							hintUseCases.generateLog(
+								id = currentGame.hintLogs.size,
+								hint = hint,
+								grid = grid,
+								stringProvider = stringProvider,
+							)
+
+						_uiState.update {
+							it.copy(
+								lastHint = hint,
+							)
+						}
+
+						currentGame.copy(
 							grid = grid,
-							stringProvider = stringProvider,
+							hintLogs = currentGame.hintLogs + hintLog,
+							hintsUsed = currentGame.hintsUsed + 1,
 						)
-
-					_uiState.update {
-						it.copy(
-							lastHint = hint,
-						)
+					} else {
+						currentGame
 					}
-
-					currentGame.copy(
-						grid = grid,
-						hintLogs = currentGame.hintLogs + hintLog,
-						hintsUsed = currentGame.hintsUsed + 1,
-					)
-				} else {
-					currentGame
 				}
 			}
 		}
@@ -538,18 +539,18 @@ internal class SudokuGameViewModel(
 		viewModelScope.launch {
 			if (_uiState.value.gameState == GameState.VICTORY) return@launch
 			val hint: Hint = _uiState.value.lastHint ?: return@launch
-			if (game.value.grid
-					.getCellAt(hint.row, hint.col)
-					.number != 0
+			if (game.value?.grid
+					?.getCellAt(hint.row, hint.col)
+					?.number != 0
 			) {
 				return@launch
 			}
 			selectCell(hint.row, hint.col)
-			updateGame {
-				val updatedSudoku = hintUseCases.revealOnGrid(hint, game.value.grid)
-				val updatedLogs = hintUseCases.revealLastLog(game.value.hintLogs)
+			updateGame { currentGame ->
+				val updatedSudoku = hintUseCases.revealOnGrid(hint, currentGame.grid)
+				val updatedLogs = hintUseCases.revealLastLog(currentGame.hintLogs)
 
-				it.copy(
+				currentGame.copy(
 					grid = updatedSudoku,
 					hintLogs = updatedLogs,
 				)
@@ -565,7 +566,7 @@ internal class SudokuGameViewModel(
 		viewModelScope.launch {
 			if (_uiState.value.gameState == GameState.VICTORY) return@launch
 
-			val cell = game.value.grid.getCellAt(row, column)
+			val cell = game.value?.grid?.getCellAt(row, column) ?: return@launch
 			if (cell.cornerNotes.size == 1) {
 				selectCell(row, column)
 				inputNumber(
@@ -580,16 +581,18 @@ internal class SudokuGameViewModel(
 
 	private fun handleFindMistakes() {
 		viewModelScope.launch {
-			val mistakes = gameManagementUseCases.findMistakes(game.value)
-			_uiState.update {
-				it.copy(
-					foundMistakes = mistakes.toPersistentList(),
-					snackbarState = if (mistakes.isNotEmpty()) {
-						SnackbarState.FoundMistakes(mistakes.size)
-					} else {
-						SnackbarState.NoMistakesFound
-					},
-				)
+			game.value?.let { currentGame ->
+				val mistakes = gameManagementUseCases.findMistakes(currentGame)
+				_uiState.update {
+					it.copy(
+						foundMistakes = mistakes.toPersistentList(),
+						snackbarState = if (mistakes.isNotEmpty()) {
+							SnackbarState.FoundMistakes(mistakes.size)
+						} else {
+							SnackbarState.NoMistakesFound
+						},
+					)
+				}
 			}
 		}
 	}

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -326,18 +326,18 @@ internal class SudokuGameViewModel(
 		viewModelScope.launch {
 			if (uiState.value.gameState == GameState.VICTORY) return@launch
 			val (row, col) = selectedCell ?: return@launch
-			val (updatedGrid, changes) = gameManagementUseCases.calculateGridChanges(
-				initialGrid = game.value.grid,
-				row = row,
-				column = col,
-				number = number,
-				isNote = isNote,
-				isHint = isHint,
-			)
-			recordUndoOperation(changes)
-			val updatedLogs = handleHintGuess(row, col, number)
-			updateGame {
-				it.copy(
+			updateGame { currentGame ->
+				val (updatedGrid, changes) = gameManagementUseCases.calculateGridChanges(
+					initialGrid = currentGame.grid,
+					row = row,
+					column = col,
+					number = number,
+					isNote = isNote,
+					isHint = isHint,
+				)
+				recordUndoOperation(changes)
+				val updatedLogs = handleHintGuess(row, col, number)
+				currentGame.copy(
 					grid = updatedGrid,
 					hintLogs = updatedLogs.toPersistentList(),
 				)
@@ -403,6 +403,7 @@ internal class SudokuGameViewModel(
 					it.copy(
 						gameState = GameState.VICTORY,
 						isNewBestTime = it.currentBestTime == null || it.currentBestTime >= elapsedTime.value,
+						focusedCells = persistentSetOf(),
 					)
 				}
 				elapsedTimerManager.stopTracking()
@@ -467,27 +468,34 @@ internal class SudokuGameViewModel(
 			game.value.hintLogs.lastOrNull()?.isRevealed?.let { if (!it) return@launch }
 
 			val hint: Hint? = hintUseCases.provideHint(game.value)
-			if (hint != null) {
-				val grid = game.value.grid
-				selectCell(hint.row, hint.col)
-				hintFocus(hint)
-				val hintLog =
-					hintUseCases.generateLog(
-						id = game.value.hintLogs.size,
-						hint = hint,
+			updateGame { currentGame ->
+				if (hint != null) {
+					val grid = gameManagementUseCases.selectCell(
+						sudoku = currentGame.grid,
+						selectedCell = hint.row to hint.col,
+					)
+					hintFocus(hint)
+					val hintLog =
+						hintUseCases.generateLog(
+							id = game.value.hintLogs.size,
+							hint = hint,
+							grid = grid,
+							stringProvider = stringProvider,
+						)
+
+					_uiState.update {
+						it.copy(
+							lastHint = hint,
+						)
+					}
+
+					currentGame.copy(
 						grid = grid,
-						stringProvider = stringProvider,
+						hintLogs = currentGame.hintLogs + hintLog,
+						hintsUsed = currentGame.hintsUsed + 1,
 					)
-				updateGame {
-					it.copy(
-						hintLogs = it.hintLogs + hintLog,
-						hintsUsed = it.hintsUsed + 1,
-					)
-				}
-				_uiState.update {
-					it.copy(
-						lastHint = hint,
-					)
+				} else {
+					currentGame
 				}
 			}
 		}
@@ -537,11 +545,10 @@ internal class SudokuGameViewModel(
 				return@launch
 			}
 			selectCell(hint.row, hint.col)
-
-			val updatedSudoku = hintUseCases.revealOnGrid(hint, game.value.grid)
-			val updatedLogs = hintUseCases.revealLastLog(game.value.hintLogs)
-
 			updateGame {
+				val updatedSudoku = hintUseCases.revealOnGrid(hint, game.value.grid)
+				val updatedLogs = hintUseCases.revealLastLog(game.value.hintLogs)
+
 				it.copy(
 					grid = updatedSudoku,
 					hintLogs = updatedLogs,
@@ -591,15 +598,17 @@ internal class SudokuGameViewModel(
 		viewModelScope.launch {
 			val mistakesToShow = _uiState.value.foundMistakes
 			if (mistakesToShow.isEmpty()) return@launch
-			var updatedGrid = game.value.grid
-			for ((row, col) in mistakesToShow) {
-				updatedGrid = updatedGrid.updateCell(row, col) {
-					it.copy(
-						attributes = it.attributes + CellAttributes.SOLUTION_CONFLICT,
-					)
+			updateGame { currentGame ->
+				var updatedGrid = currentGame.grid
+				for ((row, col) in mistakesToShow) {
+					updatedGrid = updatedGrid.updateCell(row, col) {
+						it.copy(
+							attributes = it.attributes + CellAttributes.SOLUTION_CONFLICT,
+						)
+					}
 				}
+				currentGame.copy(grid = updatedGrid)
 			}
-			updateGame { it.copy(grid = updatedGrid) }
 			_uiState.update {
 				it.copy(
 					foundMistakes = persistentListOf(),


### PR DESCRIPTION
This pull request refactors the handling of the `Game` object in both the `SudokuGameScreen` composable and the `SudokuGameViewModel`. The changes fix an issue where SudokuBoard was shown with empty data instead of loading indicator. Additionally, several usages of the `Game` object are now safely guarded against null values.

**UI and Composables Refactoring:**

* The `SudokuGameScreenContent` and related composables now accept a nullable `game: Game?` and properly handle cases where the game is not loaded, showing a loading indicator when necessary. The bottom sheet and other UI elements use safe access to `game` properties. [[1]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L100-R100) [[2]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8R133-R161)
* The logic for displaying keypad and post-game actions has been extracted into a new `GameActions` composable, improving code modularity and readability. [[1]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L185-L214) [[2]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L227-R246) [[3]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L280-R291) [[4]](diffhunk://#diff-016c5c995b98197157e1f578464e51d607a3f6681aecdb673616229c339c7be8L297-L325)

**ViewModel and State Management Improvements:**

* The `game` property in `SudokuGameViewModel` is now nullable, and all usages are updated to handle null values safely, preventing crashes when the game state is not available. [[1]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L87-R89) [[2]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L110-R101) [[3]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R228-R247)
* All game-related actions (such as saving, updating, handling hints, mistakes, and input) now use safe calls or early returns if the game is null, ensuring robust state management. [[1]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R324-R326) [[2]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L339-R335) [[3]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R348-R354) [[4]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L397-R418) [[5]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R431) [[6]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L467-R500) [[7]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L533-R553) [[8]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L561-R569) [[9]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L576-R585) [[10]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R598-R614)

**Code Cleanup:**

* Unused imports related to game difficulty and solution grid are removed, streamlining the codebase. [[1]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L7) [[2]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L28)
* Improved flow handling by filtering out null values before collecting game state updates.

These changes collectively improve the safety, maintainability, and clarity of the Sudoku game feature code.