### PR TITLE
Chore/update dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,13 +46,14 @@ android {
 			applicationIdSuffix = ".debug"
 		}
 	}
-	compileOptions {
-		sourceCompatibility = JavaVersion.VERSION_11
-		targetCompatibility = JavaVersion.VERSION_11
+	java {
+		toolchain {
+			languageVersion.set(JavaLanguageVersion.of(17))
+		}
 	}
 	kotlin {
 		compilerOptions {
-			jvmTarget = JvmTarget.JVM_11
+			jvmTarget = JvmTarget.JVM_17
 		}
 	}
 	buildFeatures {

--- a/app/src/main/java/com/example/sudokuslayer/AppContent.kt
+++ b/app/src/main/java/com/example/sudokuslayer/AppContent.kt
@@ -25,9 +25,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
-import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
-import androidx.navigation3.ui.rememberSceneSetupNavEntryDecorator
 import com.example.domain.settings.models.ColorScheme
 import com.example.domain.settings.models.DarkMode
 import com.example.feature.creator.PuzzlePreset
@@ -40,7 +39,6 @@ import com.example.feature.settings.settingsEntry
 import com.example.feature.statistics.Insights
 import com.example.feature.statistics.insightsEntry
 import com.example.feature.uicore.components.SudokuNavigationRail
-import com.example.feature.uicore.navigation.Destination
 import com.example.feature.uicore.theme.SudokuSlayerTheme
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
@@ -64,7 +62,7 @@ class MyApplication : Application() {
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun AppContent(viewModel: AppViewModel = koinViewModel()) {
-	val backstack = rememberNavBackStack<Destination>(SudokuCreator())
+	val backstack = rememberNavBackStack(SudokuCreator())
 	val navigationRailState = rememberWideNavigationRailState(
 		initialValue = WideNavigationRailValue.Collapsed,
 	)
@@ -126,8 +124,7 @@ internal fun AppContent(viewModel: AppViewModel = koinViewModel()) {
 				),
 			backStack = backstack,
 			entryDecorators = listOf(
-				rememberSceneSetupNavEntryDecorator(),
-				rememberSavedStateNavEntryDecorator(),
+				rememberSaveableStateHolderNavEntryDecorator(),
 				rememberViewModelStoreNavEntryDecorator(),
 			),
 			entryProvider = entryProvider {

--- a/build-logic/conventions/src/main/kotlin/AndroidLibraryConvention.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/AndroidLibraryConvention.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
 	alias(libs.plugins.android.library)
 	alias(libs.plugins.kotlin.android)
@@ -23,15 +21,6 @@ android {
 	buildTypes {
 		release {
 			isMinifyEnabled = false
-		}
-	}
-	compileOptions {
-		sourceCompatibility = JavaVersion.VERSION_11
-		targetCompatibility = JavaVersion.VERSION_11
-	}
-	kotlin {
-		compilerOptions {
-			jvmTarget = JvmTarget.JVM_11
 		}
 	}
 }

--- a/build-logic/conventions/src/main/kotlin/DomainModuleConvention.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/DomainModuleConvention.gradle.kts
@@ -1,20 +1,8 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
-
 plugins {
 	id("KtlintConvention")
 	alias(libs.plugins.jetbrains.kotlin.jvm)
 }
 
-java {
-	sourceCompatibility = JavaVersion.VERSION_11
-	targetCompatibility = JavaVersion.VERSION_11
-}
-kotlin {
-	compilerOptions {
-		jvmTarget = JvmTarget.JVM_11
-	}
-}
 dependencies {
 	implementation(libs.koin.core)
 	implementation(libs.kotlinx.coroutines.core)
@@ -31,14 +19,5 @@ tasks.test {
 	useJUnitPlatform()
 	testLogging {
 		events("passed", "skipped", "failed")
-	}
-}
-
-tasks.withType<JavaCompile>().configureEach {
-	options.release.set(11)
-}
-tasks.withType<KotlinJvmCompile>().configureEach {
-	compilerOptions {
-		jvmTarget = JvmTarget.JVM_11
 	}
 }

--- a/build-logic/conventions/src/main/kotlin/KtlintConvention.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/KtlintConvention.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 ktlint {
-	version = "1.5.0"
+	version = "1.7.1"
 	ignoreFailures = false
 	android = false
 	filter {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,15 @@ plugins {
 	alias(libs.plugins.android.library) apply false
 	alias(libs.plugins.ktlint) apply false
 }
+
+allprojects {
+	afterEvaluate {
+		extensions.findByType(JavaPluginExtension::class)?.toolchain {
+			languageVersion.set(JavaLanguageVersion.of(17))
+		}
+	}
+}
+
 subprojects {
 	tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
 		compilerOptions {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,15 +2,6 @@ plugins {
 	id("java-library")
 	alias(libs.plugins.jetbrains.kotlin.jvm)
 }
-java {
-	sourceCompatibility = JavaVersion.VERSION_11
-	targetCompatibility = JavaVersion.VERSION_11
-}
-kotlin {
-	compilerOptions {
-		jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
-	}
-}
 
 dependencies {
 	implementation(libs.kotlinx.coroutines.core)

--- a/data/game/src/main/java/com/example/data/game/ProtoGameSerializer.kt
+++ b/data/game/src/main/java/com/example/data/game/ProtoGameSerializer.kt
@@ -9,7 +9,7 @@ class ProtoGameSerializer : Serializer<ProtoGame> {
 		get() =
 			ProtoGame.getDefaultInstance()
 
-	override suspend fun serialize(data: ProtoGame): ByteArray = data.toByteArray()
+	override suspend fun serialize(value: ProtoGame): ByteArray = value.toByteArray()
 
 	override suspend fun deserialize(data: ByteArray): ProtoGame = try {
 		ProtoGame.parseFrom(data)

--- a/feature/creator/src/main/java/com/example/feature/creator/CreatorRoute.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/CreatorRoute.kt
@@ -4,9 +4,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.ui.Modifier
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import com.example.domain.core.GameDifficulty
 import com.example.domain.core.SudokuGridSize
 import com.example.feature.uicore.navigation.AppIcon
@@ -23,7 +22,7 @@ data class SudokuCreator(val args: PuzzlePreset? = null) : Destination {
 	override val icon: AppIcon = AppIcon.VectorIcon(Icons.Default.Add)
 }
 
-fun EntryProviderBuilder<NavKey>.sudokuCreatorEntry(
+fun EntryProviderScope<NavKey>.sudokuCreatorEntry(
 	navigateToGameScreen: () -> Unit,
 	openDrawer: () -> Unit,
 ) {

--- a/feature/creator/src/main/java/com/example/feature/creator/components/preview/BoardLoadingIndicator.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/components/preview/BoardLoadingIndicator.kt
@@ -33,7 +33,7 @@ internal fun BoardLoadingIndicator(
 	animationSpec: InfiniteRepeatableSpec<Float> = infiniteRepeatable(
 		animation = tween(1800, easing = LinearEasing),
 		repeatMode = RepeatMode.Restart,
-	)
+	),
 ) {
 	val infiniteTransition = rememberInfiniteTransition(label = "game_creation_transition")
 	val waveWidth = 4f
@@ -97,7 +97,7 @@ private fun BoardLoadingIndicatorPreview() {
 	SudokuCreatorTheme {
 		BoardLoadingIndicator(
 			gridSize = SudokuGridSize.NINE,
-			modifier = Modifier.size(200.dp)
+			modifier = Modifier.size(200.dp),
 		)
 	}
 }

--- a/feature/creator/src/main/java/com/example/feature/creator/components/preview/DrawUtilis.kt
+++ b/feature/creator/src/main/java/com/example/feature/creator/components/preview/DrawUtilis.kt
@@ -127,7 +127,7 @@ internal fun DrawScope.drawCellIllumination(
 						color = color,
 						alpha = alpha,
 						topLeft = Offset(x = col * cellSize, y = row * cellSize),
-						size = Size(cellSize, cellSize)
+						size = Size(cellSize, cellSize),
 					)
 				}
 			}

--- a/feature/game/src/main/java/com/example/feature/game/GameRoute.kt
+++ b/feature/game/src/main/java/com/example/feature/game/GameRoute.kt
@@ -2,9 +2,8 @@ package com.example.feature.game
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import com.example.feature.uicore.navigation.AppIcon
 import com.example.feature.uicore.navigation.Destination
 import com.example.sudokuslayer.feature.game.R
@@ -18,7 +17,7 @@ data object SudokuGame : Destination {
 	override val icon: AppIcon = AppIcon.ResourceIcon(R.drawable.tag)
 }
 
-fun EntryProviderBuilder<NavKey>.gameEntry(
+fun EntryProviderScope<NavKey>.gameEntry(
 	openDrawer: () -> Unit,
 	onPlayAgainClick: () -> Unit,
 	onNavigateToInsightsClick: () -> Unit,

--- a/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/com/example/feature/game/SudokuGameViewModel.kt
@@ -54,9 +54,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.datetime.Clock.System
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 internal class SudokuGameViewModel(
 	private val application: Application,
@@ -79,7 +80,7 @@ internal class SudokuGameViewModel(
 	)
 	private val updateGameMutex = Mutex()
 
-	private val _uiState = MutableStateFlow<SudokuGameUiState>(SudokuGameUiState())
+	private val _uiState = MutableStateFlow(SudokuGameUiState())
 	val uiState: StateFlow<SudokuGameUiState> = _uiState
 	private var hintFocusJob: Job? = null
 
@@ -389,6 +390,7 @@ internal class SudokuGameViewModel(
 		}
 	}
 
+	@OptIn(ExperimentalTime::class)
 	private fun handleAllCellsFilled() {
 		viewModelScope.launch {
 			game.value?.let { currentGame ->
@@ -412,7 +414,7 @@ internal class SudokuGameViewModel(
 							difficulty = currentGame.difficulty,
 							gridSize = gridSize,
 							hintsUsed = currentGame.hintsUsed,
-							completionDate = System.now().toLocalDateTime(
+							completionDate = Clock.System.now().toLocalDateTime(
 								TimeZone.currentSystemDefault(),
 							),
 							seed = currentGame.grid.seed,

--- a/feature/game/src/main/java/com/example/feature/game/components/HintsDialog.kt
+++ b/feature/game/src/main/java/com/example/feature/game/components/HintsDialog.kt
@@ -48,8 +48,9 @@ internal fun HintsDialog(
 ) {
 	val buttons =
 		listOf(
-			HintDialogButton(
-				stringResource(R.string.hint_cell), onHintClick, { Icon(Icons.Default.Face, null) }),
+			HintDialogButton(stringResource(R.string.hint_cell), onHintClick, {
+				Icon(Icons.Default.Face, null)
+			}),
 			HintDialogButton(
 				stringResource(R.string.show_hint_logs),
 				onShowLogsClick,

--- a/feature/settings/src/main/java/com/example/feature/settings/SettingsRoute.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/SettingsRoute.kt
@@ -4,9 +4,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.Modifier
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import com.example.feature.uicore.navigation.AppIcon
 import com.example.feature.uicore.navigation.Destination
 import com.example.sudokuslayer.feature.settings.R
@@ -20,7 +19,7 @@ data object Settings : Destination {
 	override val icon: AppIcon = AppIcon.VectorIcon(Icons.Default.Settings)
 }
 
-fun EntryProviderBuilder<NavKey>.settingsEntry(openDrawer: () -> Unit) {
+fun EntryProviderScope<NavKey>.settingsEntry(openDrawer: () -> Unit) {
 	entry<Settings> {
 		val viewModel = koinViewModel<SettingsViewModel>()
 		SettingsScreen(

--- a/feature/settings/src/main/java/com/example/feature/settings/components/SettingItem.kt
+++ b/feature/settings/src/main/java/com/example/feature/settings/components/SettingItem.kt
@@ -6,10 +6,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
@@ -105,14 +105,13 @@ internal fun <T> SettingDropDownMenu(
 					trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpanded) },
 					modifier =
 					Modifier
-						.menuAnchor(type = MenuAnchorType.PrimaryNotEditable)
+						.menuAnchor(type = ExposedDropdownMenuAnchorType.PrimaryNotEditable)
 						.width(200.dp),
 				)
 
 				ExposedDropdownMenu(
 					expanded = isExpanded,
 					onDismissRequest = { onExpandedChange(false) },
-					containerColor = MaterialTheme.colorScheme.surface,
 				) {
 					options.forEach { option ->
 						DropdownMenuItem(

--- a/feature/statistics/src/main/java/com/example/feature/statistics/StatisticsRoute.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/StatisticsRoute.kt
@@ -3,9 +3,8 @@ package com.example.feature.statistics
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import com.example.domain.core.GameDifficulty
 import com.example.domain.core.SudokuGridSize
 import com.example.feature.statistics.insights.InsightsScreen
@@ -23,7 +22,7 @@ data object Insights : Destination {
 }
 
 @OptIn(ExperimentalSharedTransitionApi::class)
-fun EntryProviderBuilder<NavKey>.insightsEntry(
+fun EntryProviderScope<NavKey>.insightsEntry(
 	openDrawer: () -> Unit,
 	onNavigateToGameScreen: () -> Unit,
 	onNavigateToCreator: (Long, SudokuGridSize, GameDifficulty) -> Unit,

--- a/feature/statistics/src/main/java/com/example/feature/statistics/StatisticsViewModel.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/StatisticsViewModel.kt
@@ -28,12 +28,13 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 internal data class FilterUiState(
 	val isSolveTimeRangeEnabled: Boolean = false,
@@ -167,7 +168,6 @@ internal class StatisticsViewModel(
 			is StatisticsEvent.PlayFirstGame -> handlePlayFirstGame()
 		}
 	}
-
 
 	private fun loadInitialData() {
 		viewModelScope.launch {
@@ -469,6 +469,7 @@ fun <T> PersistentList<T>.moveItem(fromIndex: Int, toIndex: Int): PersistentList
 	}.toPersistentList()
 }
 
+@OptIn(ExperimentalTime::class)
 internal fun LocalDateTime.toLong(timeZone: TimeZone = TimeZone.currentSystemDefault()): Long {
 	val instant = this.toInstant(timeZone)
 	return instant.toEpochMilliseconds()
@@ -482,6 +483,7 @@ internal fun LocalDateTime.atEndOfDay(
 	second = 59,
 )
 
+@OptIn(ExperimentalTime::class)
 internal fun Long.toLocalDateTime(
 	timeZone: TimeZone = TimeZone.currentSystemDefault(),
 ): LocalDateTime {

--- a/feature/statistics/src/main/java/com/example/feature/statistics/filter/components/VisibleColumnsView.kt
+++ b/feature/statistics/src/main/java/com/example/feature/statistics/filter/components/VisibleColumnsView.kt
@@ -29,13 +29,15 @@ internal fun VisibleColumnsView(
 		},
 	) { index, item, isDragging ->
 		key(item.column) {
-			GenericFilterChip(
-				isSelected = item.visible,
-				isDraggable = true,
-				label = item.column.getDisplayText(),
-				onClick = { toggleVisibility(item.column) },
-				modifier = Modifier.fillMaxWidth().draggableHandle(),
-			)
+			ReorderableItem {
+				GenericFilterChip(
+					isSelected = item.visible,
+					isDraggable = true,
+					label = item.column.getDisplayText(),
+					onClick = { toggleVisibility(item.column) },
+					modifier = Modifier.fillMaxWidth().draggableHandle(),
+				)
+			}
 		}
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,9 +33,9 @@ junit5TestCompose = "1.9.0"
 testCoreKtx = "1.7.0"
 testExt = "1.3.0"
 mockkVersion = "1.14.6"
-ktlint = "13.1.0"
 espressoCore = "3.7.0"
 
+ktlint = "13.1.0"
 ktlintCompose = "0.4.27"
 koin = "4.1.1"
 
@@ -43,9 +43,9 @@ koin = "4.1.1"
 protoDatastore = "1.1.7"
 preferencesDatastore = "1.1.7"
 protobufPlugin = "0.9.5"
-protobufKotlinLite = "4.31.1"
-protobufJavaLite = "4.31.1"
-protoc = "4.31.1"
+protobufKotlinLite = "4.32.1"
+protobufJavaLite = "4.32.1"
+protoc = "4.32.1"
 sqldelight = "2.1.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,24 +1,24 @@
 [versions]
 
 # Android
-agp = "8.11.1"
+kotlin = "2.2.20"
+agp = "8.13.0"
 android-compileSdk = "36"
 android-minSdk = "26"
 android-targetSdk = "35"
 
-kotlin = "2.2.0"
-coreKtx = "1.16.0"
-lifecycleRuntimeKtx = "2.9.2"
-composeBom = "2025.07.01"
+coreKtx = "1.17.0"
+lifecycleRuntimeKtx = "2.9.4"
+composeBom = "2025.10.00"
 annotations = "1.9.1"
-activityCompose = "1.10.1"
-nav3core = "1.0.0-alpha06"
+activityCompose = "1.11.0"
+nav3core = "1.0.0-alpha11"
 lifecycleViewmodelNav3 = "1.0.0-alpha04"
 
-composeUnstyled = "1.36.0"
-reorderable = "2.5.1"
-graphics-shapes = "1.1.0-alpha01"
-confettikit = "0.5.0"
+composeUnstyled = "1.45.0"
+reorderable = "3.0.0"
+graphics-shapes = "1.1.0-rc01"
+confettikit = "0.6.0"
 
 # Kotlinx
 kotlinxImmutableCollections = "0.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,21 +23,21 @@ confettikit = "0.6.0"
 # Kotlinx
 kotlinxImmutableCollections = "0.4.0"
 kotlinxCoroutinesCore = "1.10.2"
-kotlinxDatetime = "0.6.2"
-kotlinxSerializationJson = "1.8.1"
+kotlinxDatetime = "0.7.1"
+kotlinxSerializationJson = "1.9.0"
 
 
-junit5 = "5.13.1"
-androidJunit5 = "1.13.0.0"
-junit5TestCompose = "1.8.0"
-testCoreKtx = "1.6.1"
-testExt = "1.2.1"
-mockkVersion = "1.14.4"
-ktlint = "12.3.0"
-espressoCore = "3.6.1"
+junit5 = "6.0.0"
+androidJunit5 = "1.14.0.0"
+junit5TestCompose = "1.9.0"
+testCoreKtx = "1.7.0"
+testExt = "1.3.0"
+mockkVersion = "1.14.6"
+ktlint = "13.1.0"
+espressoCore = "3.7.0"
 
-ktlintCompose = "0.4.22"
-koin = "4.1.0"
+ktlintCompose = "0.4.27"
+koin = "4.1.1"
 
 # Data
 protoDatastore = "1.1.7"

--- a/sudoku-core/build.gradle.kts
+++ b/sudoku-core/build.gradle.kts
@@ -3,17 +3,6 @@ plugins {
 	alias(libs.plugins.jetbrains.kotlin.jvm)
 }
 
-java {
-	sourceCompatibility = JavaVersion.VERSION_11
-	targetCompatibility = JavaVersion.VERSION_11
-}
-
-kotlin {
-	compilerOptions {
-		jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
-	}
-}
-
 testing {
 	suites {
 		named<JvmTestSuite>("test") {


### PR DESCRIPTION
This pull request upgrades the project's Java and Kotlin toolchain to version 17 and updates related build configurations and dependencies. In addition, it refactors navigation and entry provider APIs throughout the codebase to use updated interfaces, and applies some minor code cleanups. The most important changes are grouped below.

**Toolchain and Build Configuration Updates:**

* Upgraded Java and Kotlin toolchain to version 17 across all modules and build logic, removing previous Java 11 compatibility settings from `app/build.gradle.kts`, `build-logic/conventions/src/main/kotlin/AndroidLibraryConvention.gradle.kts`, `build-logic/conventions/src/main/kotlin/DomainModuleConvention.gradle.kts`, and `core/build.gradle.kts`. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L49-R56) [[2]](diffhunk://#diff-6a5a0484302954bb5633561e8ba0ff8f9eb8c2335c94ad34be1a1ad64bacdd8aL28-L36) [[3]](diffhunk://#diff-404cad3ca6fca0dcdcbb5b53cfb8d13c2b39d3294247a450935ecb62416dcdeaL1-L17) [[4]](diffhunk://#diff-404cad3ca6fca0dcdcbb5b53cfb8d13c2b39d3294247a450935ecb62416dcdeaL36-L44) [[5]](diffhunk://#diff-a6fced4b4e4a99784a2b92028b1adbc8c0ca28ff54e264b0e73727b3d4a460cfL5-L13)
* Increased Gradle JVM memory allocation to 4096m in `gradle.properties` for improved build performance.

**Navigation and Entry Provider Refactoring:**

* Refactored navigation code to use `EntryProviderScope` instead of the deprecated `EntryProviderBuilder`, and updated related entry functions in feature modules (`CreatorRoute.kt`, `GameRoute.kt`, `SettingsRoute.kt`, `StatisticsRoute.kt`). [[1]](diffhunk://#diff-d34451c88a7eecde1c3d7fdfcb9069e1ff9eb2f7772f4f02f5a843517111dc09L7-L9) [[2]](diffhunk://#diff-d34451c88a7eecde1c3d7fdfcb9069e1ff9eb2f7772f4f02f5a843517111dc09L26-R25) [[3]](diffhunk://#diff-aad1a72e60d96f400251b39f5d6e5f9698f7b45af37dde080543e0ea2bffdfe1L5-L7) [[4]](diffhunk://#diff-aad1a72e60d96f400251b39f5d6e5f9698f7b45af37dde080543e0ea2bffdfe1L21-R20) [[5]](diffhunk://#diff-816b7cc16f7fc82a05c2ac031a7cc952aad4ee26ecf278813e4fc72bd87b9e72L7-L9) [[6]](diffhunk://#diff-816b7cc16f7fc82a05c2ac031a7cc952aad4ee26ecf278813e4fc72bd87b9e72L23-R22) [[7]](diffhunk://#diff-825442a3227d19e9e6d04c8c39319da6e59287aeca43cfb54a395d0bea3b381aL6-L8) [[8]](diffhunk://#diff-825442a3227d19e9e6d04c8c39319da6e59287aeca43cfb54a395d0bea3b381aL26-R25)
* Updated navigation decorators and state handling in `AppContent.kt` to use new APIs and removed unnecessary type parameters. [[1]](diffhunk://#diff-d78e5c66d24cea6223a8fba4c52e56a0e04209e9860c519276b1c4d2378e9dd0L28-L30) [[2]](diffhunk://#diff-d78e5c66d24cea6223a8fba4c52e56a0e04209e9860c519276b1c4d2378e9dd0L43) [[3]](diffhunk://#diff-d78e5c66d24cea6223a8fba4c52e56a0e04209e9860c519276b1c4d2378e9dd0L67-R65) [[4]](diffhunk://#diff-d78e5c66d24cea6223a8fba4c52e56a0e04209e9860c519276b1c4d2378e9dd0L129-R127)

**API Improvements:**
* Updated serialization method parameter naming in `ProtoGameSerializer.kt` for clarity.

**Time and Date Handling Modernization:**

* Migrated date/time APIs to use `kotlin.time.Clock` and added `@OptIn(ExperimentalTime::class)` annotations where required, replacing usages of `kotlinx.datetime.Clock.System`. [[1]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L57-R60) [[2]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9R393) [[3]](diffhunk://#diff-9dc500d761930c686284d810d1d2ffc035a82c07f84b119850dbb407fdaa0af9L415-R417) [[4]](diffhunk://#diff-14a3b735146802d2c1274ac26661df7aa54f4da3dd902c1c2fc3571624cd7e87L31-R37) [[5]](diffhunk://#diff-14a3b735146802d2c1274ac26661df7aa54f4da3dd902c1c2fc3571624cd7e87R472) [[6]](diffhunk://#diff-14a3b735146802d2c1274ac26661df7aa54f4da3dd902c1c2fc3571624cd7e87R486)

**UI and Component Updates:**

* Updated UI components to use new anchor types and removed deprecated properties in settings dropdown menus. [[1]](diffhunk://#diff-8ec5dd7607a672940f954c06cb7dd5c58ea95e00a2243f09d95d959f248347f0R9-L12) [[2]](diffhunk://#diff-8ec5dd7607a672940f954c06cb7dd5c58ea95e00a2243f09d95d959f248347f0L108-L115) [[3]](diffhunk://#diff-7e35fc419c5633317ef9a1559ff99134d03443eb4ba3763458653a884682cd2bR32) [[4]](diffhunk://#diff-7e35fc419c5633317ef9a1559ff99134d03443eb4ba3763458653a884682cd2bR43)