### PR TITLE
Refactor/inconsistent paddings

### DIFF
--- a/feature/creator/src/main/java/io/github/mgrablo/sudokuslayer/feature/creator/CreatorRoute.kt
+++ b/feature/creator/src/main/java/io/github/mgrablo/sudokuslayer/feature/creator/CreatorRoute.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import io.github.mgrablo.sudokuslayer.domain.core.GameDifficulty
 import io.github.mgrablo.sudokuslayer.domain.core.SudokuGridSize
 import io.github.mgrablo.sudokuslayer.feature.uicore.navigation.AppIcon
@@ -31,6 +32,7 @@ fun EntryProviderScope<NavKey>.sudokuCreatorEntry(
 		}
 		SudokuCreatorScreen(
 			onNavigateToGameScreen = navigateToGameScreen,
+			navAnimatedContentScope = LocalNavAnimatedContentScope.current,
 			openDrawer = openDrawer,
 			viewModel = viewModel,
 			modifier = Modifier.fillMaxSize(),

--- a/feature/creator/src/main/java/io/github/mgrablo/sudokuslayer/feature/creator/SudokuCreatorScreen.kt
+++ b/feature/creator/src/main/java/io/github/mgrablo/sudokuslayer/feature/creator/SudokuCreatorScreen.kt
@@ -8,8 +8,10 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
@@ -269,6 +271,8 @@ private fun InitialContent(
 				)
 			},
 		horizontalAlignment = Alignment.CenterHorizontally,
+		verticalArrangement = Arrangement.spacedBy(LocalPadding.current.small),
+		contentPadding = PaddingValues(LocalPadding.current.small)
 	) {
 		item {
 			AnimatedVisibility(visible = hasActiveGame) {
@@ -280,7 +284,7 @@ private fun InitialContent(
 					completed = uiState.savedGame.completed,
 					onContinueClick = onContinueClick,
 					onToggle = onToggleCardClick,
-					modifier = Modifier.padding(LocalPadding.current.small),
+					modifier = Modifier,
 				)
 			}
 		}
@@ -311,7 +315,6 @@ private fun InitialContent(
 				selectedSize = uiState.selectedGridSize,
 				onCheckedChange = onGridSizeChange,
 				modifier = Modifier
-					.padding(LocalPadding.current.small)
 					.fillMaxWidth(),
 			)
 		}
@@ -321,7 +324,6 @@ private fun InitialContent(
 				selectedDifficulty = uiState.selectedDifficulty,
 				onCheckedChange = onDifficulyChange,
 				modifier = Modifier
-					.padding(LocalPadding.current.small)
 					.fillMaxWidth(),
 			)
 		}
@@ -332,7 +334,6 @@ private fun InitialContent(
 				seed = uiState.advancedOptionsState.seedInput,
 				onSeedChange = onSeedChange,
 				modifier = Modifier
-					.padding(LocalPadding.current.small)
 					.fillMaxWidth(),
 			)
 		}

--- a/feature/creator/src/main/java/io/github/mgrablo/sudokuslayer/feature/creator/SudokuCreatorScreen.kt
+++ b/feature/creator/src/main/java/io/github/mgrablo/sudokuslayer/feature/creator/SudokuCreatorScreen.kt
@@ -1,5 +1,6 @@
 package io.github.mgrablo.sudokuslayer.feature.creator
 
+import android.content.res.Configuration
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
@@ -51,11 +52,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.flowWithLifecycle
-import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import io.github.mgrablo.sudokucore.model.SolutionGrid
 import io.github.mgrablo.sudokucore.model.SudokuGrid
 import io.github.mgrablo.sudokuslayer.domain.core.Game
@@ -89,6 +89,7 @@ private val PreviewBoxSize = 200.dp
 internal fun SudokuCreatorScreen(
 	onNavigateToGameScreen: (SudokuGridSize) -> Unit,
 	openDrawer: () -> Unit,
+	navAnimatedContentScope: AnimatedVisibilityScope,
 	modifier: Modifier = Modifier,
 	viewModel: SudokuCreatorViewModel = koinViewModel(),
 ) {
@@ -96,6 +97,7 @@ internal fun SudokuCreatorScreen(
 
 	SudokuCreatorTheme(false) {
 		SudokuCreatorContent(
+			navAnimatedContentScope = navAnimatedContentScope,
 			uiState = uiState,
 			onEvent = viewModel::onEvent,
 			openDrawer = openDrawer,
@@ -113,6 +115,7 @@ internal fun SudokuCreatorScreen(
 @Composable
 private fun SudokuCreatorContent(
 	uiState: SudokuCreatorUiState,
+	navAnimatedContentScope: AnimatedVisibilityScope,
 	onEvent: (Event) -> Unit,
 	openDrawer: () -> Unit,
 	onNavigateToGameScreen: (SudokuGridSize) -> Unit,
@@ -198,6 +201,7 @@ private fun SudokuCreatorContent(
 								onSeedChange = { onEvent(Event.ChangePuzzleSeed(it)) },
 								sharedTransitionScope = this@SharedTransitionLayout,
 								animatedVisibilityScope = this,
+								navAnimatedContentScope = navAnimatedContentScope,
 								modifier = Modifier
 									.fillMaxWidth()
 									.sharedBounds(
@@ -212,6 +216,7 @@ private fun SudokuCreatorContent(
 								selectedGridSize = uiState.selectedGridSize,
 								sharedTransitionScope = this@SharedTransitionLayout,
 								animatedVisibilityScope = this,
+								navAnimatedContentScope = navAnimatedContentScope,
 								modifier = Modifier
 									.weight(1f)
 									.sharedBounds(
@@ -240,6 +245,7 @@ private fun InitialContent(
 	onSeedChange: (String) -> Unit,
 	sharedTransitionScope: SharedTransitionScope,
 	animatedVisibilityScope: AnimatedVisibilityScope,
+	navAnimatedContentScope: AnimatedVisibilityScope,
 	modifier: Modifier = Modifier,
 ) {
 	val hasActiveGame by remember(uiState) {
@@ -283,7 +289,7 @@ private fun InitialContent(
 				val sharedLoadingIndicatorModifier = with(LocalSharedTransitionScope.current) {
 					Modifier.sharedElement(
 						rememberSharedContentState(SharedElementKey.BoardLoadingIndicator),
-						animatedVisibilityScope = LocalNavAnimatedContentScope.current,
+						animatedVisibilityScope = navAnimatedContentScope,
 					)
 				}
 				BoardPreview(
@@ -292,7 +298,8 @@ private fun InitialContent(
 						.sharedBounds(
 							rememberSharedContentState(CreatorSharedElementKey.BoardPreview),
 							animatedVisibilityScope = animatedVisibilityScope,
-						).then(sharedLoadingIndicatorModifier),
+						)
+						.then(sharedLoadingIndicatorModifier),
 					state = boardPreviewState,
 				)
 			}
@@ -338,6 +345,7 @@ private fun LoadingContent(
 	selectedGridSize: SudokuGridSize,
 	sharedTransitionScope: SharedTransitionScope,
 	animatedVisibilityScope: AnimatedVisibilityScope,
+	navAnimatedContentScope: AnimatedVisibilityScope,
 	modifier: Modifier = Modifier,
 ) {
 	with(sharedTransitionScope) {
@@ -355,7 +363,7 @@ private fun LoadingContent(
 					with(LocalSharedTransitionScope.current) {
 						Modifier.sharedElement(
 							rememberSharedContentState(SharedElementKey.BoardLoadingIndicator),
-							animatedVisibilityScope = LocalNavAnimatedContentScope.current,
+							animatedVisibilityScope = navAnimatedContentScope,
 						)
 					}
 
@@ -373,7 +381,8 @@ private fun LoadingContent(
 						.sharedBounds(
 							rememberSharedContentState(CreatorSharedElementKey.BoardPreview),
 							animatedVisibilityScope = animatedVisibilityScope,
-						).then(sharedLoadingIndicatorModifier),
+						)
+						.then(sharedLoadingIndicatorModifier),
 				)
 				Spacer(Modifier.size(LocalPadding.current.big))
 
@@ -398,21 +407,34 @@ private fun LoadingContent(
 	}
 }
 
-@PreviewLightDark
+//region Previews
 @Composable
-private fun SudokuCreatorScreenPreview() {
+private fun SudokuCreatorScreenPreview(
+	uiState: SudokuCreatorUiState,
+) {
 	SudokuCreatorTheme {
-		SudokuCreatorContent(
-			uiState = SudokuCreatorUiState(),
-			onEvent = { },
-			openDrawer = { },
-			onNavigateToGameScreen = { },
-			modifier = Modifier.fillMaxSize(),
-		)
+		AnimatedVisibility(visible = true) {
+			SudokuCreatorContent(
+				uiState = uiState,
+				onEvent = { },
+				openDrawer = { },
+				onNavigateToGameScreen = { },
+				navAnimatedContentScope = this,
+				modifier = Modifier.fillMaxSize(),
+			)
+		}
 	}
 }
 
-@PreviewLightDark
+@Preview(name = "Initial", showBackground = true)
+@Preview(name = "Initial Dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun SudokuCreatorScreenInitialPreview() {
+	SudokuCreatorScreenPreview(uiState = SudokuCreatorUiState())
+}
+
+@Preview(name = "Active Game", showBackground = true)
+@Preview(name = "Active Game Dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SudokuCreatorScreenActiveGamePreview() {
 	val savedGame = Game(
@@ -425,21 +447,20 @@ private fun SudokuCreatorScreenActiveGamePreview() {
 		solution = SolutionGrid(intArrayOf(), 0),
 	)
 
-	SudokuCreatorTheme {
-		SudokuCreatorContent(
-			uiState = SudokuCreatorUiState(
-				savedGame = savedGame,
-				hasActiveGame = true,
-			),
-			onEvent = { },
-			openDrawer = { },
-			onNavigateToGameScreen = { },
-			modifier = Modifier.fillMaxSize(),
-		)
-	}
+	SudokuCreatorScreenPreview(
+		uiState = SudokuCreatorUiState(
+			savedGame = savedGame,
+			hasActiveGame = true,
+		),
+	)
 }
 
-@PreviewLightDark
+@Preview(name = "Active Game Expanded", showBackground = true)
+@Preview(
+	name = "Active Game Expanded Dark",
+	showBackground = true,
+	uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
 @Composable
 private fun SudokuCreatorScreenActiveGameExpandedPreview() {
 	val savedGame = Game(
@@ -452,51 +473,36 @@ private fun SudokuCreatorScreenActiveGameExpandedPreview() {
 		solution = SolutionGrid(intArrayOf(), 0),
 	)
 
-	SudokuCreatorTheme {
-		SudokuCreatorContent(
-			uiState = SudokuCreatorUiState(
-				savedGame = savedGame,
-				hasActiveGame = true,
-				activeGameCardExpanded = true,
-				advancedOptionsState = AdvancedOptionsState(
-					expanded = true,
-				),
+	SudokuCreatorScreenPreview(
+		uiState = SudokuCreatorUiState(
+			savedGame = savedGame,
+			hasActiveGame = true,
+			activeGameCardExpanded = true,
+			advancedOptionsState = AdvancedOptionsState(
+				expanded = true,
 			),
-			onEvent = { },
-			openDrawer = { },
-			onNavigateToGameScreen = { },
-			modifier = Modifier.fillMaxSize(),
-		)
-	}
+		),
+	)
 }
 
-@PreviewLightDark
+@Preview(name = "Loading", showBackground = true)
+@Preview(name = "Loading Dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SudokuCreatorScreenLoadingPreview() {
-	SudokuCreatorTheme {
-		SudokuCreatorContent(
-			uiState = SudokuCreatorUiState(loadingState = ScreenState.LOADING),
-			onEvent = { },
-			openDrawer = { },
-			onNavigateToGameScreen = { },
-			modifier = Modifier.fillMaxSize(),
-		)
-	}
+	SudokuCreatorScreenPreview(
+		uiState = SudokuCreatorUiState(loadingState = ScreenState.LOADING),
+	)
 }
 
-@PreviewLightDark
+@Preview(name = "Loading Big", showBackground = true)
+@Preview(name = "Loading Big Dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SudokuCreatorScreenLoadingBigPreview() {
-	SudokuCreatorTheme {
-		SudokuCreatorContent(
-			uiState = SudokuCreatorUiState(
-				loadingState = ScreenState.LOADING,
-				selectedGridSize = SudokuGridSize.SIXTEEN,
-			),
-			onEvent = { },
-			openDrawer = { },
-			onNavigateToGameScreen = { },
-			modifier = Modifier.fillMaxSize(),
-		)
-	}
+	SudokuCreatorScreenPreview(
+		uiState = SudokuCreatorUiState(
+			loadingState = ScreenState.LOADING,
+			selectedGridSize = SudokuGridSize.SIXTEEN,
+		),
+	)
 }
+//endregion

--- a/feature/game/src/main/java/io/github/mgrablo/sudokuslayer/feature/game/GameRoute.kt
+++ b/feature/game/src/main/java/io/github/mgrablo/sudokuslayer/feature/game/GameRoute.kt
@@ -34,7 +34,7 @@ fun EntryProviderScope<NavKey>.gameEntry(
 			onPlayAgainClick = onPlayAgainClick,
 			onNavigateToInsightsClick = onNavigateToInsightsClick,
 			viewModel = viewmodel,
-			animatedVisibilityScope = LocalNavAnimatedContentScope.current
+			navAnimatedContentScope = LocalNavAnimatedContentScope.current
 		)
 	}
 }

--- a/feature/game/src/main/java/io/github/mgrablo/sudokuslayer/feature/game/GameRoute.kt
+++ b/feature/game/src/main/java/io/github/mgrablo/sudokuslayer/feature/game/GameRoute.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import io.github.mgrablo.sudokuslayer.domain.core.SudokuGridSize
 import io.github.mgrablo.sudokuslayer.feature.uicore.navigation.AppIcon
 import io.github.mgrablo.sudokuslayer.feature.uicore.navigation.Destination
@@ -33,6 +34,7 @@ fun EntryProviderScope<NavKey>.gameEntry(
 			onPlayAgainClick = onPlayAgainClick,
 			onNavigateToInsightsClick = onNavigateToInsightsClick,
 			viewModel = viewmodel,
+			animatedVisibilityScope = LocalNavAnimatedContentScope.current
 		)
 	}
 }

--- a/feature/game/src/main/java/io/github/mgrablo/sudokuslayer/feature/game/SudokuGameScreen.kt
+++ b/feature/game/src/main/java/io/github/mgrablo/sudokuslayer/feature/game/SudokuGameScreen.kt
@@ -1,6 +1,9 @@
 package io.github.mgrablo.sudokuslayer.feature.game
 
+import android.content.res.Configuration
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -25,14 +28,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalWindowInfo
-import androidx.compose.ui.tooling.preview.Devices.AUTOMOTIVE_1024p
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import com.composables.core.rememberDialogState
 import io.github.mgrablo.sudokucore.model.SolutionGrid
 import io.github.mgrablo.sudokucore.model.SudokuGrid
@@ -69,6 +69,7 @@ internal fun SudokuGameScreen(
 	openDrawer: () -> Unit,
 	onPlayAgainClick: () -> Unit,
 	onNavigateToInsightsClick: () -> Unit,
+	animatedVisibilityScope: AnimatedVisibilityScope,
 	modifier: Modifier = Modifier,
 	viewModel: SudokuGameViewModel = koinViewModel(),
 ) {
@@ -97,6 +98,7 @@ internal fun SudokuGameScreen(
 			elapsedTime = { elapsedTime },
 			onNavigateToInsightsClick = onNavigateToInsightsClick,
 			openDrawer = openDrawer,
+			animatedVisibilityScope = animatedVisibilityScope,
 		)
 	}
 }
@@ -107,6 +109,7 @@ private fun SudokuGameScreenContent(
 	uiState: SudokuGameUiState,
 	game: Game?,
 	remainingDigitCounts: PersistentMap<Int, Int>,
+	animatedVisibilityScope: AnimatedVisibilityScope,
 	onEvent: (Event) -> Unit,
 	elapsedTime: () -> Long,
 	openDrawer: () -> Unit,
@@ -126,10 +129,10 @@ private fun SudokuGameScreenContent(
 	val scaffoldState =
 		rememberBottomSheetScaffoldState(
 			bottomSheetState =
-			rememberStandardBottomSheetState(
-				initialValue = SheetValue.Hidden,
-				skipHiddenState = false,
-			),
+				rememberStandardBottomSheetState(
+					initialValue = SheetValue.Hidden,
+					skipHiddenState = false,
+				),
 		)
 
 	LaunchedEffect(uiState.gameState) {
@@ -140,7 +143,7 @@ private fun SudokuGameScreenContent(
 
 	SharedTransitionLayout {
 		HintBottomSheetScaffold(
-			modifier = modifier,
+			modifier = modifier.fillMaxSize(),
 			sheetScaffoldState = scaffoldState,
 			snackbarState = uiState.snackbarState,
 			hintLogs = game?.hintLogs ?: persistentListOf(),
@@ -163,7 +166,7 @@ private fun SudokuGameScreenContent(
 			val sharedLoadingIndicatorModifier = with(LocalSharedTransitionScope.current) {
 				Modifier.sharedElement(
 					rememberSharedContentState(SharedElementKey.BoardLoadingIndicator),
-					animatedVisibilityScope = LocalNavAnimatedContentScope.current,
+					animatedVisibilityScope = animatedVisibilityScope,
 				)
 			}
 
@@ -358,6 +361,7 @@ private fun GameActions(
 	) { state ->
 		when (state) {
 			GameState.LOADING -> Unit
+
 			GameState.PLAYING -> {
 				KeyPad(
 					remainingDigitCounts = remainingDigitCounts,
@@ -373,6 +377,7 @@ private fun GameActions(
 					gridSize = gridSize,
 					isLeftHandMode = uiState.isLeftHandMode,
 					showActionButtonsOnTop = uiState.showActionButtonsOnTop,
+					modifier = Modifier,
 				)
 			}
 
@@ -390,92 +395,162 @@ private fun GameActions(
 	}
 }
 
-@PreviewScreenSizes
-@PreviewLightDark
+// region Previews
 @Composable
-private fun SudokuGameScreenPreview() {
+private fun SudokuGameScreenPreview(uiState: SudokuGameUiState, game: Game?) {
 	SudokuGameTheme {
-		SudokuGameScreenContent(
-			uiState = SudokuGameUiState(
-				selectedCell = 1 to 1,
-				gameState = GameState.VICTORY,
-			),
-			game =
-			Game(
-				grid = createFilledSudokuGrid(9),
-				elapsedTime = 0,
-				hintLogs = persistentListOf(),
-				hintsUsed = 0,
-				difficulty = GameDifficulty.Easy,
-				solution = SolutionGrid(intArrayOf(), 0),
-			),
-			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
-			onEvent = {},
-			elapsedTime = { 1 },
-			openDrawer = {},
-			onPlayAgainClick = { },
-			onNavigateToInsightsClick = { },
-			modifier = Modifier.fillMaxSize(),
-		)
+		AnimatedVisibility(true) {
+			SudokuGameScreenContent(
+				uiState = uiState,
+				game = game,
+				remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
+				onEvent = {},
+				elapsedTime = { 1 },
+				openDrawer = {},
+				onPlayAgainClick = { },
+				onNavigateToInsightsClick = { },
+				modifier = Modifier.fillMaxSize(),
+				animatedVisibilityScope = this,
+			)
+		}
 	}
 }
 
-@PreviewLightDark
+@Preview(name = "Loading", showBackground = true)
+@Preview(name = "Loading Dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-private fun SudokuGameScreenSixteenPreview() {
-	SudokuGameTheme {
-		SudokuGameScreenContent(
-			uiState = SudokuGameUiState(),
-			game =
-			Game(
-				grid = createFilledSudokuGrid(16),
-				elapsedTime = 0,
-				hintLogs = persistentListOf(),
-				hintsUsed = 0,
-				difficulty = GameDifficulty.Easy,
-				solution = SolutionGrid(intArrayOf(), 0),
-			),
-			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
-			onEvent = {},
-			elapsedTime = { 1 },
-			openDrawer = {},
-			onPlayAgainClick = { },
-			onNavigateToInsightsClick = { },
-			modifier = Modifier.fillMaxSize(),
-		)
-	}
+private fun SudokuGameScreenLoadingPreview() {
+	SudokuGameScreenPreview(
+		uiState = SudokuGameUiState(gameState = GameState.LOADING),
+		game = null,
+	)
 }
 
+@Preview(name = "Playing 9x9", showBackground = true)
+@Preview(name = "Playing 9x9 Dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun SudokuGameScreen9x9PlayingPreview() {
+	SudokuGameScreenPreview(
+		uiState = SudokuGameUiState(
+			selectedCell = 1 to 1,
+			gameState = GameState.PLAYING,
+		),
+		game = Game(
+			grid = createFilledSudokuGrid(9),
+			elapsedTime = 0,
+			hintLogs = persistentListOf(),
+			hintsUsed = 0,
+			difficulty = GameDifficulty.Easy,
+			solution = SolutionGrid(intArrayOf(), 0),
+		),
+	)
+}
+
+@Preview(name = "Playing 9x9 Landscape", showBackground = true, device = Devices.AUTOMOTIVE_1024p)
 @Preview(
-	device = AUTOMOTIVE_1024p,
+	name = "Playing 9x9 Landscape Dark",
+	showBackground = true,
+	device = Devices.AUTOMOTIVE_1024p,
+	uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
-private fun SudokuGameScreenFourPreview() {
-	SudokuGameTheme {
-		SudokuGameScreenContent(
-			uiState =
-			SudokuGameUiState(
-				isLeftHandMode = true,
-				gameState = GameState.PLAYING,
-			),
-			game =
-			Game(
-				grid = createFilledSudokuGrid(4),
-				elapsedTime = 0,
-				hintLogs = persistentListOf(),
-				hintsUsed = 0,
-				difficulty = GameDifficulty.Easy,
-				solution = SolutionGrid(intArrayOf(), 0),
-			),
-			remainingDigitCounts = persistentMapOf(1 to 1, 2 to 1, 3 to 1, 4 to 1),
-			onEvent = {},
-			elapsedTime = { 1 },
-			openDrawer = {},
-			onPlayAgainClick = { },
-			onNavigateToInsightsClick = { },
-			modifier = Modifier.fillMaxSize(),
-		)
-	}
+private fun SudokuGameScreen9x9PlayingLandscapePreview() {
+	SudokuGameScreenPreview(
+		uiState = SudokuGameUiState(
+			selectedCell = 1 to 1,
+			gameState = GameState.PLAYING,
+		),
+		game = Game(
+			grid = createFilledSudokuGrid(9),
+			elapsedTime = 0,
+			hintLogs = persistentListOf(),
+			hintsUsed = 0,
+			difficulty = GameDifficulty.Easy,
+			solution = SolutionGrid(intArrayOf(), 0),
+		),
+	)
+}
+
+@Preview(name = "Playing 16x16", showBackground = true)
+@Preview(
+	name = "Playing 16x16 Dark",
+	showBackground = true,
+	uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+private fun SudokuGameScreen16x16PlayingPreview() {
+	SudokuGameScreenPreview(
+		uiState = SudokuGameUiState(gameState = GameState.PLAYING),
+		game = Game(
+			grid = createFilledSudokuGrid(16),
+			elapsedTime = 0,
+			hintLogs = persistentListOf(),
+			hintsUsed = 0,
+			difficulty = GameDifficulty.Easy,
+			solution = SolutionGrid(intArrayOf(), 0),
+		),
+	)
+}
+
+@Preview(name = "Playing 4x4", showBackground = true)
+@Preview(name = "Playing 4x4 Dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun SudokuGameScreen4x4PlayingPreview() {
+	SudokuGameScreenPreview(
+		uiState = SudokuGameUiState(gameState = GameState.PLAYING),
+		game = Game(
+			grid = createFilledSudokuGrid(4),
+			elapsedTime = 0,
+			hintLogs = persistentListOf(),
+			hintsUsed = 0,
+			difficulty = GameDifficulty.Easy,
+			solution = SolutionGrid(intArrayOf(), 0),
+		),
+	)
+}
+
+@Preview(name = "Playing Left Hand Mode", showBackground = true)
+@Preview(
+	name = "Playing Left Hand Mode Dark",
+	showBackground = true,
+	uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+private fun SudokuGameScreenLeftHandModePlayingPreview() {
+	SudokuGameScreenPreview(
+		uiState = SudokuGameUiState(
+			isLeftHandMode = true,
+			gameState = GameState.PLAYING,
+		),
+		game = Game(
+			grid = createFilledSudokuGrid(9),
+			elapsedTime = 0,
+			hintLogs = persistentListOf(),
+			hintsUsed = 0,
+			difficulty = GameDifficulty.Easy,
+			solution = SolutionGrid(intArrayOf(), 0),
+		),
+	)
+}
+
+@Preview(name = "Victory", showBackground = true)
+@Preview(name = "Victory Dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun SudokuGameScreenVictoryPreview() {
+	SudokuGameScreenPreview(
+		uiState = SudokuGameUiState(
+			selectedCell = 1 to 1,
+			gameState = GameState.VICTORY,
+		),
+		game = Game(
+			grid = createFilledSudokuGrid(9),
+			elapsedTime = 0,
+			hintLogs = persistentListOf(),
+			hintsUsed = 0,
+			difficulty = GameDifficulty.Easy,
+			solution = SolutionGrid(intArrayOf(), 0),
+		),
+	)
 }
 
 private fun createFilledSudokuGrid(gridSize: Int): SudokuGrid {
@@ -485,3 +560,4 @@ private fun createFilledSudokuGrid(gridSize: Int): SudokuGrid {
 	}
 	return SudokuGrid.fromIntArray(gridRows, gridSize)
 }
+// endregion

--- a/feature/game/src/main/java/io/github/mgrablo/sudokuslayer/feature/game/SudokuGameScreen.kt
+++ b/feature/game/src/main/java/io/github/mgrablo/sudokuslayer/feature/game/SudokuGameScreen.kt
@@ -69,7 +69,7 @@ internal fun SudokuGameScreen(
 	openDrawer: () -> Unit,
 	onPlayAgainClick: () -> Unit,
 	onNavigateToInsightsClick: () -> Unit,
-	animatedVisibilityScope: AnimatedVisibilityScope,
+	navAnimatedContentScope: AnimatedVisibilityScope,
 	modifier: Modifier = Modifier,
 	viewModel: SudokuGameViewModel = koinViewModel(),
 ) {
@@ -98,7 +98,7 @@ internal fun SudokuGameScreen(
 			elapsedTime = { elapsedTime },
 			onNavigateToInsightsClick = onNavigateToInsightsClick,
 			openDrawer = openDrawer,
-			animatedVisibilityScope = animatedVisibilityScope,
+			navAnimatedContentScope = navAnimatedContentScope,
 		)
 	}
 }
@@ -109,7 +109,7 @@ private fun SudokuGameScreenContent(
 	uiState: SudokuGameUiState,
 	game: Game?,
 	remainingDigitCounts: PersistentMap<Int, Int>,
-	animatedVisibilityScope: AnimatedVisibilityScope,
+	navAnimatedContentScope: AnimatedVisibilityScope,
 	onEvent: (Event) -> Unit,
 	elapsedTime: () -> Long,
 	openDrawer: () -> Unit,
@@ -166,13 +166,13 @@ private fun SudokuGameScreenContent(
 			val sharedLoadingIndicatorModifier = with(LocalSharedTransitionScope.current) {
 				Modifier.sharedElement(
 					rememberSharedContentState(SharedElementKey.BoardLoadingIndicator),
-					animatedVisibilityScope = animatedVisibilityScope,
+					animatedVisibilityScope = navAnimatedContentScope,
 				)
 			}
 
 			AnimatedContent(
 				targetState = uiState.gameState == GameState.LOADING || game == null,
-				modifier = Modifier.padding(innerPadding),
+				modifier = Modifier.fillMaxSize().padding(LocalPadding.current.tiny),
 			) { loading ->
 				if (loading) {
 					Column(
@@ -410,7 +410,7 @@ private fun SudokuGameScreenPreview(uiState: SudokuGameUiState, game: Game?) {
 				onPlayAgainClick = { },
 				onNavigateToInsightsClick = { },
 				modifier = Modifier.fillMaxSize(),
-				animatedVisibilityScope = this,
+				navAnimatedContentScope = this,
 			)
 		}
 	}


### PR DESCRIPTION
This pull request updates both the Creator and Game feature modules to consistently pass and use the navigation animated content scope (`navAnimatedContentScope`) through their composable hierarchies. This change improves the handling of animated transitions, especially for shared elements, and also refactors and expands the preview composables for better testability and maintainability.

Key changes include:

**Navigation Animation Scope Propagation:**

- Added `LocalNavAnimatedContentScope.current` as a parameter and passed it through the navigation entry functions (`sudokuCreatorEntry`, `gameEntry`) and down to the respective screen composables (`SudokuCreatorScreen`, `SudokuGameScreen`). This ensures that all animated transitions (especially shared element transitions) use the correct scope provided by the navigation framework. [[1]](diffhunk://#diff-86fa0b491b11096bbe4457eb95adc133db4e2a8669efb4cd7cab9d40e488826fR9) [[2]](diffhunk://#diff-86fa0b491b11096bbe4457eb95adc133db4e2a8669efb4cd7cab9d40e488826fR35) [[3]](diffhunk://#diff-61b32ff01d16f6fa5e2c5e347a44d0bca0206c6ad51368d50fb9e3de0db87adcR7) [[4]](diffhunk://#diff-61b32ff01d16f6fa5e2c5e347a44d0bca0206c6ad51368d50fb9e3de0db87adcR37) [[5]](diffhunk://#diff-8f23ff2cbc66eddbe975ec87bc6a355c7411cc61ea7e175c30b0b2d4bbab2c92R3-R6) [[6]](diffhunk://#diff-8f23ff2cbc66eddbe975ec87bc6a355c7411cc61ea7e175c30b0b2d4bbab2c92R72) [[7]](diffhunk://#diff-8f23ff2cbc66eddbe975ec87bc6a355c7411cc61ea7e175c30b0b2d4bbab2c92R101)

- Updated all relevant composables (`SudokuCreatorScreen`, `SudokuCreatorContent`, `InitialContent`, `LoadingContent`, and their usages in the creator feature) to accept and forward the `navAnimatedContentScope` parameter, ensuring consistent animation context throughout the UI hierarchy. [[1]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8R94-R102) [[2]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8R120) [[3]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8R206) [[4]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8R221) [[5]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8R250) [[6]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8R349) [[7]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L358-R367)

- Replaced direct usage of `LocalNavAnimatedContentScope.current` with the passed `navAnimatedContentScope` parameter for shared element transitions, improving composability and testability. [[1]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L286-R296) [[2]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L358-R367)

**UI and Layout Improvements:**

- Improved arrangement and padding in the `InitialContent` composable by using `verticalArrangement` and `contentPadding` with spacing values from `LocalPadding`, resulting in a more consistent and visually appealing layout.

- Removed redundant `.padding(LocalPadding.current.small)` modifiers from child elements, since padding is now handled at the parent level. [[1]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L277-R287) [[2]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L307) [[3]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L317) [[4]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L328)

**Preview Refactoring and Expansion:**

- Refactored preview composables in the creator feature to use a single `SudokuCreatorScreenPreview` function, which accepts a `SudokuCreatorUiState` parameter and sets up the correct animation scope. This reduces code duplication and makes it easier to add new preview states. [[1]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L401-R438) [[2]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L428-R464) [[3]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L455-R477) [[4]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L465-R509)

- Added multiple new preview variants (light/dark, different states) for the creator screen, improving design-time testing and documentation. [[1]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L401-R438) [[2]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L428-R464) [[3]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L455-R477) [[4]](diffhunk://#diff-691bff5cd0e884f3ddc1eee08c8bf18700b1a5bafe6ea7100c71c8623e7219d8L465-R509)

These changes collectively improve the maintainability, consistency, and visual quality of the navigation transitions and UI in the Sudoku creator and game features.