### PR TITLE
Fix: Correct Frappe theme `isDark` property

### DIFF
--- a/domain/settings/src/main/java/io/github/mgrablo/sudokuslayer/domain/settings/models/ColorScheme.kt
+++ b/domain/settings/src/main/java/io/github/mgrablo/sudokuslayer/domain/settings/models/ColorScheme.kt
@@ -28,7 +28,7 @@ sealed class ColorScheme(open val name: String, open val isDark: Boolean) {
 	data class Latte(override val name: String = "latte", override val isDark: Boolean = false) :
 		ColorScheme(name, isDark)
 
-	data class Frappe(override val name: String = "frappe", override val isDark: Boolean = false) :
+	data class Frappe(override val name: String = "frappe", override val isDark: Boolean = true) :
 		ColorScheme(name, isDark)
 
 	companion object {


### PR DESCRIPTION
This commit fixes a bug in the `ColorScheme` definition for the Frappe theme. The `isDark` property was incorrectly set to `false` and has now been corrected to `true` to accurately reflect that Frappe is a dark theme.