### PR TITLE
Refactor/improve hint provider strategies

### DIFF
--- a/sudoku-core/src/main/java/io/github/mgrablo/sudokucore/hints/HintUtils.kt
+++ b/sudoku-core/src/main/java/io/github/mgrablo/sudokucore/hints/HintUtils.kt
@@ -3,13 +3,17 @@ package io.github.mgrablo.sudokucore.hints
 import io.github.mgrablo.sudokucore.model.SudokuCellData
 import kotlin.math.sqrt
 
-internal fun getRow(data: List<SudokuCellData>, row: Int): List<SudokuCellData> =
+internal fun getRowCells(data: List<SudokuCellData>, row: Int): List<SudokuCellData> =
 	data.filter { it.row == row }
 
-internal fun getColumn(data: List<SudokuCellData>, col: Int): List<SudokuCellData> =
+internal fun getColumnCells(data: List<SudokuCellData>, col: Int): List<SudokuCellData> =
 	data.filter { it.col == col }
 
-internal fun getBlock(data: List<SudokuCellData>, boxRow: Int, boxCol: Int): List<SudokuCellData> {
+internal fun getBlockCells(
+	data: List<SudokuCellData>,
+	boxRow: Int,
+	boxCol: Int,
+): List<SudokuCellData> {
 	val gridSize = sqrt(data.size.toDouble()).toInt()
 	val blockSize = sqrt(gridSize.toDouble()).toInt()
 	val startRow = boxRow * blockSize
@@ -19,6 +23,9 @@ internal fun getBlock(data: List<SudokuCellData>, boxRow: Int, boxCol: Int): Lis
 			it.col in startCol until startCol + blockSize
 	}
 }
+
+internal fun getBlockId(row: Int, col: Int, blockSize: Int): Int =
+	(row / blockSize) * blockSize + (col / blockSize)
 
 internal fun Collection<SudokuCellData>.containsCell(cell: SudokuCellData): Boolean =
 	this.any { it.row == cell.row && it.col == cell.col }

--- a/sudoku-core/src/main/java/io/github/mgrablo/sudokucore/hints/strategies/ClaimingCandidateStrategy.kt
+++ b/sudoku-core/src/main/java/io/github/mgrablo/sudokucore/hints/strategies/ClaimingCandidateStrategy.kt
@@ -4,67 +4,78 @@ import io.github.mgrablo.sudokucore.hints.GroupType
 import io.github.mgrablo.sudokucore.hints.Hint
 import io.github.mgrablo.sudokucore.hints.HintType
 import io.github.mgrablo.sudokucore.hints.containsCell
-import io.github.mgrablo.sudokucore.hints.getBlock
+import io.github.mgrablo.sudokucore.hints.getBlockCells
+import io.github.mgrablo.sudokucore.hints.getBlockId
 import io.github.mgrablo.sudokucore.model.House
 import io.github.mgrablo.sudokucore.model.SudokuCellData
 import kotlinx.collections.immutable.toPersistentSet
 import kotlin.math.sqrt
 
+/**
+ * Claiming Candidate strategy.
+ *
+ * Occurs when all occurrences of a candidate digit within a row or column are confined to a single block.
+ * This allows us to eliminate that candidate from all other cells in that same block.
+ */
 internal class ClaimingCandidateStrategy : HintStrategy {
 	override fun findHints(data: List<SudokuCellData>, houses: List<House>): List<Hint> {
-		val hints = mutableListOf<Hint>()
-		houses.filter { it is House.Row || it is House.Column }.forEach { house ->
-			hints.addAll(findClaimingCandidates(house, data))
-		}
-		return hints
-	}
-
-	private fun findClaimingCandidates(house: House, data: List<SudokuCellData>): List<Hint> {
-		val hints = mutableListOf<Hint>()
-		val candidateDigits = house.cells.flatMap { it.candidates }.toSet()
 		val gridSize = sqrt(data.size.toDouble()).toInt()
 		val blockSize = sqrt(gridSize.toDouble()).toInt()
-		for (digit in candidateDigits) {
-			val candidateCells = house.cells.filter { it.number == 0 && digit in it.candidates }
-			if (candidateCells.isNotEmpty()) {
-				val uniqueBlocks =
-					candidateCells.map { (it.row / blockSize) * blockSize + (it.col / blockSize) }
-						.toSet()
-				if (uniqueBlocks.size == 1) {
-					val blockIndex = uniqueBlocks.first()
-					val blockCells =
-						getBlock(data, blockIndex / blockSize, blockIndex % blockSize)
-							.filter {
-								!candidateCells.containsCell(it) && it.number == 0 &&
-									digit in it.candidates
-							}
 
-					if (blockCells.isNotEmpty()) {
-						// Create a single grouped hint for this claiming pattern: remove `digit` from
-						// all `blockCells` in the block since the candidate is claimed by the row/col.
-						val anchor = blockCells.first()
-						hints.add(
-							Hint(
-								row = anchor.row,
-								col = anchor.col,
-								value = digit,
-								type =
-									HintType.ClaimingCandidate(
-										if (house is House.Row) {
-											GroupType.Row(house.id)
-										} else {
-											GroupType.Column(house.id)
-										},
-									),
-								explanationStrategy = ClaimingCandidateExplanation(),
-								affectedCells = blockCells.toPersistentSet(),
-								enforcingCells = candidateCells.toPersistentSet(),
-							),
-						)
-					}
+		// Claiming candidates are found by looking at rows and columns
+		return houses.filter { it is House.Row || it is House.Column }
+			.flatMap { house -> findClaimingCandidates(house, data, blockSize) }
+	}
+
+	private fun findClaimingCandidates(
+		house: House,
+		data: List<SudokuCellData>,
+		blockSize: Int,
+	): List<Hint> {
+		val emptyCellsInHouse = house.cells.filter { it.number == 0 }
+		// The distinct digits that appear as candidates in this row/column
+		val candidateDigits = emptyCellsInHouse.flatMap { it.candidates }.distinct()
+
+		return candidateDigits.mapNotNull { digit ->
+			val cellsWithDigit = emptyCellsInHouse.filter { digit in it.candidates }
+			// A claiming candidate must appear in at least two cells in the row/column,
+			// a single candidate cell doesn't create an elimination pattern
+			if (cellsWithDigit.size < 2) return@mapNotNull null
+
+			// Check if all occurrences of this digit in the house are in the same block
+			val blockId = cellsWithDigit
+				.map { getBlockId(it.row, it.col, blockSize) }
+				.distinct()
+				.singleOrNull() ?: return@mapNotNull null
+
+			// Find cells in that same block that are NOT in the current house
+			// and contain the digit as a candidate, these are the cells where the digit can be eliminated
+			val affectedCells = getBlockCells(data, blockId / blockSize, blockId % blockSize)
+				.filter { cell ->
+					cell.number == 0 &&
+						digit in cell.candidates &&
+						!house.cells.containsCell(cell)
 				}
-			}
+
+			if (affectedCells.isEmpty()) return@mapNotNull null
+
+			// Use the first affected cell as the hint's location
+			val anchor = affectedCells.first()
+			Hint(
+				row = anchor.row,
+				col = anchor.col,
+				value = digit,
+				type = HintType.ClaimingCandidate(house.toGroupType()),
+				explanationStrategy = ClaimingCandidateExplanation(),
+				affectedCells = affectedCells.toPersistentSet(),
+				enforcingCells = cellsWithDigit.toPersistentSet(),
+			)
 		}
-		return hints
+	}
+
+	private fun House.toGroupType(): GroupType = when (this) {
+		is House.Row -> GroupType.Row(id)
+		is House.Column -> GroupType.Column(id)
+		is House.Block -> GroupType.Block(id)
 	}
 }

--- a/sudoku-core/src/main/java/io/github/mgrablo/sudokucore/hints/strategies/HiddenSingleStrategy.kt
+++ b/sudoku-core/src/main/java/io/github/mgrablo/sudokucore/hints/strategies/HiddenSingleStrategy.kt
@@ -6,35 +6,41 @@ import io.github.mgrablo.sudokucore.hints.HintType
 import io.github.mgrablo.sudokucore.model.House
 import io.github.mgrablo.sudokucore.model.SudokuCellData
 import io.github.mgrablo.sudokucore.symmetricDifference
+import kotlinx.collections.immutable.toPersistentSet
 
+/**
+ * Hidden Single strategy.
+ *
+ * Occurs when a candidate digit appears only once in a specific house (row, column, or block).
+ * Even if the cell has other candidates, this digit must be the value for that cell.
+ */
 internal class HiddenSingleStrategy : HintStrategy {
 	override fun findHints(data: List<SudokuCellData>, houses: List<House>): List<Hint> {
-		val hints = mutableListOf<Hint>()
-		for (house in houses) {
+		return houses.flatMap { house ->
 			val emptyCells = house.cells.filter { it.number == 0 }
-			if (emptyCells.isEmpty()) continue
+			if (emptyCells.isEmpty()) return@flatMap emptyList()
 
-			val diff = symmetricDifference(emptyCells.map { it.candidates })
-			if (diff.isEmpty()) continue
+			// Find digits that appear exactly once across all candidate sets in this house
+			val uniqueCandidates = symmetricDifference(emptyCells.map { it.candidates })
 
-			for (digit in diff) {
-				val hintCell = emptyCells.find { it.candidates.contains(digit) }!!
-				val hiddenSingleType = when (house) {
-					is House.Row -> HintType.HiddenSingle(GroupType.Row(house.id))
-					is House.Column -> HintType.HiddenSingle(GroupType.Column(house.id))
-					is House.Block -> HintType.HiddenSingle(GroupType.Block(house.id))
-				}
-				hints.add(
-					Hint(
-						row = hintCell.row,
-						col = hintCell.col,
-						value = digit,
-						type = hiddenSingleType,
-						explanationStrategy = HiddenSingleExplanation(),
-					),
+			uniqueCandidates.map { digit ->
+				val hintCell = emptyCells.first { digit in it.candidates }
+				Hint(
+					row = hintCell.row,
+					col = hintCell.col,
+					value = digit,
+					type = HintType.HiddenSingle(house.toGroupType()),
+					explanationStrategy = HiddenSingleExplanation(),
+					// The other cells in the house are enforcing this cell to have this digit
+					enforcingCells = house.cells.toPersistentSet(),
 				)
 			}
 		}
-		return hints
+	}
+
+	private fun House.toGroupType(): GroupType = when (this) {
+		is House.Row -> GroupType.Row(id)
+		is House.Column -> GroupType.Column(id)
+		is House.Block -> GroupType.Block(id)
 	}
 }

--- a/sudoku-core/src/main/java/io/github/mgrablo/sudokucore/hints/strategies/NakedSingleStrategy.kt
+++ b/sudoku-core/src/main/java/io/github/mgrablo/sudokucore/hints/strategies/NakedSingleStrategy.kt
@@ -5,8 +5,16 @@ import io.github.mgrablo.sudokucore.hints.HintType
 import io.github.mgrablo.sudokucore.model.House
 import io.github.mgrablo.sudokucore.model.SudokuCellData
 
+/**
+ * Naked Single strategy.
+ *
+ * Occurs when a cell has only one possible candidate remaining.
+ * Since all other digits are already present in the same row, column, or block,
+ * this remaining digit must be the value for the cell.
+ */
 internal class NakedSingleStrategy : HintStrategy {
 	override fun findHints(data: List<SudokuCellData>, houses: List<House>): List<Hint> =
+		// A naked single is any empty cell that has exactly one candidate left in its list
 		data.filter { it.number == 0 && it.candidates.size == 1 }
 			.map { cell ->
 				Hint(

--- a/sudoku-core/src/main/java/io/github/mgrablo/sudokucore/hints/strategies/PointingCandidateStrategy.kt
+++ b/sudoku-core/src/main/java/io/github/mgrablo/sudokucore/hints/strategies/PointingCandidateStrategy.kt
@@ -4,78 +4,101 @@ import io.github.mgrablo.sudokucore.hints.GroupType
 import io.github.mgrablo.sudokucore.hints.Hint
 import io.github.mgrablo.sudokucore.hints.HintType
 import io.github.mgrablo.sudokucore.hints.containsCell
-import io.github.mgrablo.sudokucore.hints.getColumn
-import io.github.mgrablo.sudokucore.hints.getRow
+import io.github.mgrablo.sudokucore.hints.getColumnCells
+import io.github.mgrablo.sudokucore.hints.getRowCells
 import io.github.mgrablo.sudokucore.model.House
 import io.github.mgrablo.sudokucore.model.SudokuCellData
 import kotlinx.collections.immutable.toPersistentSet
 
+/**
+ * Pointing Candidate strategy.
+ *
+ * Occurs when all occurrences of a candidate digit within a block are aligned in a single row or column.
+ * This allows us to eliminate that candidate from all other cells in that same row or column outside the block.
+ */
 internal class PointingCandidateStrategy : HintStrategy {
-	override fun findHints(data: List<SudokuCellData>, houses: List<House>): List<Hint> {
-		val hints = mutableListOf<Hint>()
-		houses.filterIsInstance<House.Block>().forEach { house ->
-			hints.addAll(findPointingCandidates(house, data))
+	override fun findHints(data: List<SudokuCellData>, houses: List<House>): List<Hint> =
+		// Pointing candidates are found by analyzing blocks
+		houses.filterIsInstance<House.Block>().flatMap { house ->
+			findPointingCandidates(house, data)
 		}
-		return hints
+
+	private fun findPointingCandidates(block: House.Block, data: List<SudokuCellData>): List<Hint> {
+		val emptyCellsInBlock = block.cells.filter { it.number == 0 }
+		// Identify all unique candidate digits currently present in this block
+		val candidateDigits = emptyCellsInBlock.flatMap { it.candidates }.distinct()
+
+		return candidateDigits.flatMap { digit ->
+			val cellsWithDigit = emptyCellsInBlock.filter { digit in it.candidates }
+			
+			// A pointing candidate requires at least two cells to form a line.
+			// If it's only in one cell, it might be a Hidden Single instead.
+			if (cellsWithDigit.size < 2) return@flatMap emptyList()
+
+			// Check both row and column directions for potential alignment
+			listOfNotNull(
+				checkDirection(
+					digit = digit,
+					candidateCells = cellsWithDigit,
+					blockCells = block.cells,
+					fullGridData = data,
+					getGroupId = { it.row },
+					getGroupCells = ::getRowCells,
+					createGroupType = { GroupType.Row(it) },
+				),
+				checkDirection(
+					digit = digit,
+					candidateCells = cellsWithDigit,
+					blockCells = block.cells,
+					fullGridData = data,
+					getGroupId = { it.col },
+					getGroupCells = ::getColumnCells,
+					createGroupType = { GroupType.Column(it) },
+				),
+			)
+		}
 	}
 
-	private fun findPointingCandidates(house: House.Block, data: List<SudokuCellData>): List<Hint> {
-		val hints = mutableListOf<Hint>()
-		val emptyCells = house.cells.filter { it.number == 0 }
-		val candidateDigits = emptyCells.flatMap { it.candidates }.toSet()
-		for (digit in candidateDigits) {
-			val candidateCells = emptyCells.filter { digit in it.candidates }
-			if (candidateCells.size < 2) continue
+	/**
+	 * Check if all candidate cells for this digit are aligned in one row/column.
+	 * If so, eliminate the digit from other cells in that row/column outside the block.
+	 */
+	private fun checkDirection(
+		digit: Int,
+		candidateCells: List<SudokuCellData>,
+		blockCells: List<SudokuCellData>,
+		fullGridData: List<SudokuCellData>,
+		getGroupId: (SudokuCellData) -> Int,
+		getGroupCells: (List<SudokuCellData>, Int) -> List<SudokuCellData>,
+		createGroupType: (Int) -> GroupType,
+	): Hint? {
+		// Check if all candidate cells are in the same row/column.
+		val groupId = candidateCells
+			.map(getGroupId)
+			.distinct()
+			.singleOrNull() ?: return null
 
-			val uniqueRows = candidateCells.map { it.row }.toSet()
-			val uniqueCols = candidateCells.map { it.col }.toSet()
-
-			// Candidate is pointing in a row
-			if (uniqueRows.size == 1) {
-				val rowCells =
-					getRow(data, uniqueRows.first())
-						.filter { !emptyCells.containsCell(it) && it.number == 0 }
-						.filter { digit in it.candidates }
-
-				if (rowCells.isNotEmpty()) {
-					val anchor = rowCells.first()
-					hints.add(
-						Hint(
-							row = anchor.row,
-							col = anchor.col,
-							value = digit,
-							type = HintType.PointingCandidate(GroupType.Row(anchor.row)),
-							explanationStrategy = PointingCandidateExplanation(),
-							affectedCells = rowCells.toPersistentSet(),
-							enforcingCells = candidateCells.toPersistentSet(),
-						),
-					)
-				}
+		// Find cells in the same row/column that are OUTSIDE the current block.
+		// If any of these cells contain the digit as a candidate, they can be eliminated.
+		val affectedCells = getGroupCells(fullGridData, groupId)
+			.filter { cell ->
+				cell.number == 0 &&
+					digit in cell.candidates &&
+					!blockCells.containsCell(cell)
 			}
 
-			// Candidate is pointing in a column
-			if (uniqueCols.size == 1) {
-				val colCells =
-					getColumn(data, uniqueCols.first())
-						.filter { !emptyCells.containsCell(it) && it.number == 0 }
-						.filter { digit in it.candidates }
+		if (affectedCells.isEmpty()) return null
 
-				if (colCells.isNotEmpty()) {
-					val anchor = colCells.first()
-					hints.add(
-						Hint(
-							row = anchor.row,
-							col = anchor.col,
-							value = digit,
-							type = HintType.PointingCandidate(GroupType.Column(anchor.col)),
-							explanationStrategy = PointingCandidateExplanation(),
-							affectedCells = colCells.toPersistentSet(),
-							enforcingCells = candidateCells.toPersistentSet(),
-						),
-					)
-				}
-			}
-		}
-		return hints
+		// Use the first affected cell as the hint's location
+		val anchor = affectedCells.first()
+		return Hint(
+			row = anchor.row,
+			col = anchor.col,
+			value = digit,
+			type = HintType.PointingCandidate(createGroupType(groupId)),
+			explanationStrategy = PointingCandidateExplanation(),
+			affectedCells = affectedCells.toPersistentSet(),
+			enforcingCells = candidateCells.toPersistentSet(),
+		)
 	}
 }

--- a/sudoku-core/src/test/kotlin/io/github/mgrablo/sudokucore/TestUtils.kt
+++ b/sudoku-core/src/test/kotlin/io/github/mgrablo/sudokucore/TestUtils.kt
@@ -1,0 +1,46 @@
+package io.github.mgrablo.sudokucore
+
+import io.github.mgrablo.sudokucore.model.House
+import io.github.mgrablo.sudokucore.model.SudokuCellData
+import io.github.mgrablo.sudokucore.model.SudokuGrid
+import io.github.mgrablo.sudokucore.model.updateCells
+import kotlinx.collections.immutable.toPersistentSet
+import kotlin.math.sqrt
+
+/**
+ * Generates all houses (rows, columns, and blocks) for the given grid data.
+ */
+fun generateHouses(data: List<SudokuCellData>): List<House> {
+	val gridSize = sqrt(data.size.toDouble()).toInt()
+	val blockSize = sqrt(gridSize.toDouble()).toInt()
+
+	return buildList {
+		(0 until gridSize).forEach { i ->
+			add(House.Row(data.filter { it.row == i }, i))
+			add(House.Column(data.filter { it.col == i }, i))
+		}
+		for (r in 0 until gridSize step blockSize) {
+			for (c in 0 until gridSize step blockSize) {
+				val blockId = (r / blockSize) * blockSize + (c / blockSize)
+				val blockCells = data.filter {
+					it.row in r until r + blockSize && it.col in c until c + blockSize
+				}
+				add(House.Block(blockCells, blockId))
+			}
+		}
+	}
+}
+
+/**
+ * Sets candidates for a specific cell. Useful for unit testing hint strategies in isolation.
+ */
+fun SudokuGrid.withCandidates(row: Int, col: Int, vararg candidates: Int): SudokuGrid =
+	updateCell(row, col) { it.copy(candidates = candidates.toSet().toPersistentSet()) }
+
+/**
+ * Sets candidates for multiple cells at once using a map of (row, col) to candidates.
+ */
+fun SudokuGrid.withCandidates(candidatesMap: Map<Pair<Int, Int>, Set<Int>>): SudokuGrid =
+	updateCells({ (it.row to it.col) in candidatesMap.keys }) { cell ->
+		cell.copy(candidates = (candidatesMap[cell.row to cell.col] ?: emptySet()).toPersistentSet())
+	}

--- a/sudoku-core/src/test/kotlin/io/github/mgrablo/sudokucore/hints/strategies/ClaimingCandidateStrategyTest.kt
+++ b/sudoku-core/src/test/kotlin/io/github/mgrablo/sudokucore/hints/strategies/ClaimingCandidateStrategyTest.kt
@@ -1,0 +1,117 @@
+package io.github.mgrablo.sudokucore.hints.strategies
+
+import io.github.mgrablo.sudokucore.generateHouses
+import io.github.mgrablo.sudokucore.hints.GroupType
+import io.github.mgrablo.sudokucore.hints.HintType
+import io.github.mgrablo.sudokucore.model.SudokuGrid
+import io.github.mgrablo.sudokucore.withCandidates
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+
+class ClaimingCandidateStrategyTest {
+	private val claimingCandidateStrategy = ClaimingCandidateStrategy()
+
+	@Test
+	fun `should find claiming candidate in a row`() {
+		// In row 0, digit 1 only appears inside block 0, so it can be eliminated from other cells in block 0
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2)
+			.withCandidates(0, 1, 1, 3)
+			.withCandidates(1, 1, 1) // affected cell in block 0
+			.withCandidates(4, 1, 1) // 1 outside block 0 to break column candidate
+		val houses = generateHouses(grid.data)
+
+		val hints = claimingCandidateStrategy.findHints(grid.data, houses)
+
+		val rowHint = hints.singleOrNull {
+			it.type is HintType.ClaimingCandidate &&
+				it.type.groupType is GroupType.Row
+		}
+		assertNotNull(rowHint)
+		assertEquals(1, rowHint.row)
+		assertEquals(1, rowHint.col)
+		assertEquals(1, rowHint.value)
+
+		val rowType = rowHint.type as HintType.ClaimingCandidate
+		assertEquals(GroupType.Row(0), rowType.groupType)
+
+		assertTrue(rowHint.enforcingCells.all { it.row == 0 && it.col < 3 })
+		assertTrue(rowHint.affectedCells.all { it.row / 3 == 0 && it.col / 3 == 0 })
+		assertTrue(rowHint.affectedCells.isNotEmpty())
+	}
+
+	@Test
+	fun `should find claiming candidate in a column`() {
+		// In column 0, digit 1 only appears inside block 0, so it can be eliminated from other cells in block 0
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2)
+			.withCandidates(1, 0, 1, 3)
+			.withCandidates(0, 1, 1) // same block, same column, keeps the pattern active
+			.withCandidates(0, 4, 1) // 1 outside block 0 to break row candidate
+		val houses = generateHouses(grid.data)
+
+		val hints = claimingCandidateStrategy.findHints(grid.data, houses)
+
+		val colHint = hints.singleOrNull {
+			it.type is HintType.ClaimingCandidate &&
+				it.type.groupType is GroupType.Column
+		}
+		assertNotNull(colHint)
+		assertEquals(0, colHint.row)
+		assertEquals(1, colHint.col)
+		assertEquals(1, colHint.value)
+
+		val colType = colHint.type as HintType.ClaimingCandidate
+		assertEquals(GroupType.Column(0), colType.groupType)
+
+		assertTrue(colHint.enforcingCells.all { it.col == 0 && it.row < 3 })
+		assertTrue(colHint.affectedCells.all { it.row / 3 == 0 && it.col / 3 == 0 })
+		assertTrue(colHint.affectedCells.isNotEmpty())
+	}
+
+	@Test
+	fun `should return multiple hints when multiple claiming candidates exist`() {
+		val grid = SudokuGrid()
+			// row 0 => claiming candidate for digit 1 in block 0
+			.withCandidates(0, 0, 1, 2)
+			.withCandidates(0, 1, 1, 3)
+			.withCandidates(1, 0, 1, 4)
+			.withCandidates(1, 1, 2)
+			// column 8 => claiming candidate for digit 9 in block 2
+			.withCandidates(0, 8, 9, 5)
+			.withCandidates(1, 8, 9, 6)
+			.withCandidates(2, 7, 9, 7)
+		val houses = generateHouses(grid.data)
+
+		val hints = claimingCandidateStrategy.findHints(grid.data, houses)
+
+		assertTrue(hints.size >= 2)
+		assertTrue(
+			hints.any {
+				it.value == 1 && it.type is HintType.ClaimingCandidate &&
+					it.type.groupType is GroupType.Row
+			},
+		)
+		assertTrue(
+			hints.any {
+				it.value == 9 && it.type is HintType.ClaimingCandidate &&
+					it.type.groupType is GroupType.Column
+			},
+		)
+	}
+
+	@Test
+	fun `should return empty list when no claiming candidate exists`() {
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2)
+			.withCandidates(0, 4, 1, 3) // same row, different block
+			.withCandidates(1, 0, 1, 4) // different row, same block
+		val houses = generateHouses(grid.data)
+
+		val hints = claimingCandidateStrategy.findHints(grid.data, houses)
+
+		assertTrue(hints.isEmpty())
+	}
+}

--- a/sudoku-core/src/test/kotlin/io/github/mgrablo/sudokucore/hints/strategies/HiddenSingleStrategyTest.kt
+++ b/sudoku-core/src/test/kotlin/io/github/mgrablo/sudokucore/hints/strategies/HiddenSingleStrategyTest.kt
@@ -1,0 +1,107 @@
+package io.github.mgrablo.sudokucore.hints.strategies
+
+import io.github.mgrablo.sudokucore.generateHouses
+import io.github.mgrablo.sudokucore.hints.GroupType
+import io.github.mgrablo.sudokucore.hints.HintType
+import io.github.mgrablo.sudokucore.model.SudokuGrid
+import io.github.mgrablo.sudokucore.withCandidates
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+
+class HiddenSingleStrategyTest {
+	private val hiddenSingleStrategy = HiddenSingleStrategy()
+
+	@Test
+	fun `should find hidden single in a row`() {
+		// In row 0, digit 1 only appears as a candidate in (0,0)
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2)
+			.withCandidates(0, 1, 2)
+		val houses = generateHouses(grid.data)
+
+		val hints = hiddenSingleStrategy.findHints(grid.data, houses)
+
+		val rowHint = hints.singleOrNull {
+			it.type is HintType.HiddenSingle && it.type.groupType is GroupType.Row
+		}
+		assertNotNull(rowHint)
+		assertEquals(0, rowHint.row)
+		assertEquals(0, rowHint.col)
+		assertEquals(1, rowHint.value)
+	}
+
+	@Test
+	fun `should find hidden single in a column`() {
+		// In column 0, digit 1 only appears as a candidate in (0,0)
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2)
+			.withCandidates(1, 0, 2)
+			.withCandidates(0, 1, 1) // Breaks Row 0 hidden single
+			.withCandidates(1, 1, 1) // Breaks Block 0 hidden single
+		val houses = generateHouses(grid.data)
+
+		val hints = hiddenSingleStrategy.findHints(grid.data, houses)
+
+		val colHint = hints.singleOrNull {
+			it.type is HintType.HiddenSingle && it.type.groupType is GroupType.Column
+		}
+		assertNotNull(colHint)
+		assertEquals(0, colHint.row)
+		assertEquals(0, colHint.col)
+		assertEquals(1, colHint.value)
+	}
+
+	@Test
+	fun `should find hidden single in a block`() {
+		// In block 0 (top-left), digit 1 only appears as a candidate in (0,0)
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2) // the block hidden single candidate
+			.withCandidates(0, 1, 2)
+			.withCandidates(1, 0, 2)
+			.withCandidates(1, 1, 2)
+		val houses = generateHouses(grid.data)
+
+		val hints = hiddenSingleStrategy.findHints(grid.data, houses)
+
+		val blockHint = hints.find {
+			it.type is HintType.HiddenSingle &&
+				it.type.groupType is GroupType.Block &&
+				it.value == 1 && it.row == 0 && it.col == 0
+		}
+		assertNotNull(blockHint)
+		assertEquals(0, blockHint.row)
+		assertEquals(0, blockHint.col)
+		assertEquals(1, blockHint.value)
+	}
+
+	@Test
+	fun `should return all hidden singles when multiple exist`() {
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2) // 1 can only go into (0, 0)
+			.withCandidates(0, 1, 2)
+			.withCandidates(8, 8, 9, 7) // 9 can only go into (8, 8)
+			.withCandidates(8, 7, 7)
+		val houses = generateHouses(grid.data)
+
+		val hints = hiddenSingleStrategy.findHints(grid.data, houses)
+
+		assertTrue(hints.any { it.value == 1 && it.row == 0 && it.col == 0 })
+		assertTrue(hints.any { it.value == 9 && it.row == 8 && it.col == 8 })
+	}
+
+	@Test
+	fun `should return empty list when no hidden single is found`() {
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2)
+			.withCandidates(0, 1, 1, 2)
+			.withCandidates(1, 0, 1, 2)
+			.withCandidates(1, 1, 1, 2)
+		val houses = generateHouses(grid.data)
+
+		val hints = hiddenSingleStrategy.findHints(grid.data, houses)
+
+		assertTrue(hints.isEmpty())
+	}
+}

--- a/sudoku-core/src/test/kotlin/io/github/mgrablo/sudokucore/hints/strategies/NakedSingleStrategyTest.kt
+++ b/sudoku-core/src/test/kotlin/io/github/mgrablo/sudokucore/hints/strategies/NakedSingleStrategyTest.kt
@@ -1,0 +1,148 @@
+package io.github.mgrablo.sudokucore.hints.strategies
+
+import io.github.mgrablo.sudokucore.generateHouses
+import io.github.mgrablo.sudokucore.hints.HintType
+import io.github.mgrablo.sudokucore.model.SudokuGrid
+import io.github.mgrablo.sudokucore.withCandidates
+import kotlinx.collections.immutable.persistentSetOf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NakedSingleStrategyTest {
+	private val nakedSingleStrategy = NakedSingleStrategy()
+
+	@Test
+	fun `should find naked single in a row`() {
+		val grid = SudokuGrid.fromStringArray(
+			listOf(
+				"123456780",
+				"000000000",
+				"000000000",
+				"000000000",
+				"000000000",
+				"000000000",
+				"000000000",
+				"000000000",
+				"000000000",
+			),
+		).withCandidates(0, 8, 9) // Only digit 9 can go into (0, 8)
+		val houses = generateHouses(grid.data)
+
+		val hints = nakedSingleStrategy.findHints(grid.data, houses)
+
+		assertEquals(1, hints.size)
+		assertEquals(0, hints[0].row)
+		assertEquals(8, hints[0].col)
+		assertEquals(9, hints[0].value)
+		assertEquals(HintType.NakedSingle, hints[0].type)
+	}
+
+	@Test
+	fun `should find naked single in a column`() {
+		val grid = SudokuGrid.fromStringArray(
+			listOf(
+				"100000000",
+				"200000000",
+				"300000000",
+				"400000000",
+				"500000000",
+				"600000000",
+				"700000000",
+				"800000000",
+				"000000000",
+			),
+		).withCandidates(8, 0, 9) // Only digit 9 can go into (8, 0)
+		val houses = generateHouses(grid.data)
+
+		val hints = nakedSingleStrategy.findHints(grid.data, houses)
+
+		assertEquals(1, hints.size)
+		assertEquals(8, hints[0].row)
+		assertEquals(0, hints[0].col)
+		assertEquals(9, hints[0].value)
+	}
+
+	@Test
+	fun `should find naked single in a block`() {
+		val grid = SudokuGrid.fromStringArray(
+			listOf(
+				"123000000",
+				"406000000",
+				"789000000",
+				"000000000",
+				"000000000",
+				"000000000",
+				"000000000",
+				"000000000",
+				"000000000",
+			),
+		).withCandidates(1, 1, 5) // Only digit 5 can go into (1, 1)
+		val houses = generateHouses(grid.data)
+
+		val hints = nakedSingleStrategy.findHints(grid.data, houses)
+
+		assertEquals(1, hints.size)
+		assertEquals(1, hints[0].row)
+		assertEquals(1, hints[0].col)
+		assertEquals(5, hints[0].value)
+	}
+
+	@Test
+	fun `should return all naked singles when multiple exist`() {
+		val grid = SudokuGrid.fromStringArray(
+			listOf(
+				"103456789",
+				"200000000",
+				"300000000",
+				"400000000",
+				"500000000",
+				"600000000",
+				"700000000",
+				"800000000",
+				"000000000",
+			),
+		).withCandidates(8, 0, 9) // Only digit 9 can go into (8, 0)
+			.withCandidates(0, 1, 2) // Only digit 2 can go into (0, 1)
+		val houses = generateHouses(grid.data)
+
+		val hints = nakedSingleStrategy.findHints(grid.data, houses)
+
+		assertEquals(2, hints.size)
+		assertEquals(9, hints.find { it.row == 8 && it.col == 0 }?.value)
+		assertEquals(2, hints.find { it.row == 0 && it.col == 1 }?.value)
+	}
+
+	@Test
+	fun `should ignore cells with more than one candidate`() {
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2)
+		val houses = generateHouses(grid.data)
+
+		val hints = nakedSingleStrategy.findHints(grid.data, houses)
+
+		assertEquals(0, hints.size)
+	}
+
+	@Test
+	fun `should ignore filled cells even if they have one candidate`() {
+		val grid = SudokuGrid()
+			.updateCell(0, 0) {
+				it.copy(number = 5, candidates = persistentSetOf(1))
+			}
+		val houses = generateHouses(grid.data)
+
+		val hints = nakedSingleStrategy.findHints(grid.data, houses)
+
+		assertEquals(0, hints.size)
+	}
+
+	@Test
+	fun `should return empty list when no naked single is found`() {
+		val grid = SudokuGrid()
+		val houses = generateHouses(grid.data)
+
+		val hints = nakedSingleStrategy.findHints(grid.data, houses)
+
+		assertEquals(0, hints.size)
+	}
+}

--- a/sudoku-core/src/test/kotlin/io/github/mgrablo/sudokucore/hints/strategies/PointingCandidateStrategyTest.kt
+++ b/sudoku-core/src/test/kotlin/io/github/mgrablo/sudokucore/hints/strategies/PointingCandidateStrategyTest.kt
@@ -1,0 +1,120 @@
+package io.github.mgrablo.sudokucore.hints.strategies
+
+import io.github.mgrablo.sudokucore.generateHouses
+import io.github.mgrablo.sudokucore.hints.GroupType
+import io.github.mgrablo.sudokucore.hints.HintType
+import io.github.mgrablo.sudokucore.model.SudokuGrid
+import io.github.mgrablo.sudokucore.withCandidates
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+
+class PointingCandidateStrategyTest {
+	private val pointingCandidateStrategy = PointingCandidateStrategy()
+
+	@Test
+	fun `should find pointing candidate in a row`() {
+		// In block 0, digit 1 only appears in row 0, so it can be eliminated from row 0 outside the block
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2)
+			.withCandidates(0, 1, 1, 3)
+			.withCandidates(0, 3, 1, 4) // outside block 0, same row
+			.withCandidates(1, 0, 2)
+			.withCandidates(1, 1, 2)
+		val houses = generateHouses(grid.data)
+
+		val hints = pointingCandidateStrategy.findHints(grid.data, houses)
+
+		val rowHint = hints.singleOrNull {
+			it.type is HintType.PointingCandidate &&
+				it.type.groupType is GroupType.Row
+		}
+		assertNotNull(rowHint)
+		// Hint row/col are taken from the first affected cell
+		assertEquals(0, rowHint.row)
+		assertEquals(3, rowHint.col)
+		assertEquals(1, rowHint.value)
+
+		val rowType = rowHint.type as HintType.PointingCandidate
+		assertEquals(GroupType.Row(0), rowType.groupType)
+
+		assertTrue(rowHint.enforcingCells.all { it.row == 0 && it.col < 3 })
+		assertTrue(rowHint.affectedCells.all { it.row == 0 && it.col >= 3 })
+		assertTrue(rowHint.affectedCells.isNotEmpty())
+	}
+
+	@Test
+	fun `should find pointing candidate in a column`() {
+		// In block 0, digit 1 only appears in column 0, so it can be eliminated from column 0 outside the block
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2)
+			.withCandidates(1, 0, 1, 3)
+			.withCandidates(3, 0, 1, 4) // outside block 0, same column
+			.withCandidates(0, 1, 2)
+			.withCandidates(1, 1, 2)
+		val houses = generateHouses(grid.data)
+
+		val hints = pointingCandidateStrategy.findHints(grid.data, houses)
+
+		val colHint = hints.singleOrNull {
+			it.type is HintType.PointingCandidate &&
+				it.type.groupType is GroupType.Column
+		}
+		assertNotNull(colHint)
+		// Hint row/col are taken from the first affected cell
+		assertEquals(3, colHint.row)
+		assertEquals(0, colHint.col)
+		assertEquals(1, colHint.value)
+
+		val colType = colHint.type as HintType.PointingCandidate
+		assertEquals(GroupType.Column(0), colType.groupType)
+
+		assertTrue(colHint.enforcingCells.all { it.col == 0 && it.row < 3 })
+		assertTrue(colHint.affectedCells.all { it.col == 0 && it.row >= 3 })
+		assertTrue(colHint.affectedCells.isNotEmpty())
+	}
+
+	@Test
+	fun `should return multiple hints when multiple pointing candidates exist`() {
+		val grid = SudokuGrid()
+			// block 0: row pointing candidate for digit 1
+			.withCandidates(0, 0, 1, 2)
+			.withCandidates(0, 1, 1, 3)
+			.withCandidates(0, 3, 1, 4)
+			// block 4: column pointing candidate for digit 9
+			.withCandidates(3, 3, 9, 2)
+			.withCandidates(4, 3, 9, 5)
+			.withCandidates(6, 3, 9, 7)
+		val houses = generateHouses(grid.data)
+
+		val hints = pointingCandidateStrategy.findHints(grid.data, houses)
+
+		assertTrue(hints.size >= 2)
+		assertTrue(
+			hints.any {
+				it.value == 1 && it.type is HintType.PointingCandidate &&
+					it.type.groupType is GroupType.Row
+			},
+		)
+		assertTrue(
+			hints.any {
+				it.value == 9 && it.type is HintType.PointingCandidate &&
+					it.type.groupType is GroupType.Column
+			},
+		)
+	}
+
+	@Test
+	fun `should return empty list when no pointing candidate exists`() {
+		val grid = SudokuGrid()
+			.withCandidates(0, 0, 1, 2)
+			.withCandidates(0, 1, 1, 3)
+			.withCandidates(1, 0, 1, 4) // spread across multiple rows, so no pointing candidate
+		val houses = generateHouses(grid.data)
+
+		val hints = pointingCandidateStrategy.findHints(grid.data, houses)
+
+		assertTrue(hints.isEmpty())
+	}
+}


### PR DESCRIPTION
This pull request improves the clarity, maintainability, and testability of the Sudoku hint strategies by refactoring utility functions, simplifying and documenting strategy implementations, and adding comprehensive unit tests. The changes also introduce new helper functions for working with Sudoku houses and candidates, and enhance code readability and correctness.

**Refactoring and API Improvements:**

- Renamed utility functions in `HintUtils.kt` for clarity (`getRow` → `getRowCells`, `getColumn` → `getColumnCells`, `getBlock` → `getBlockCells`) and added a new `getBlockId` helper for determining block indices. [[1]](diffhunk://#diff-80b05d8738a8e929070bfff54ef62c012694e6ee03782cbc2a95e4d208c8d393L6-R16) [[2]](diffhunk://#diff-80b05d8738a8e929070bfff54ef62c012694e6ee03782cbc2a95e4d208c8d393R27-R29)

**Hint Strategy Enhancements:**

- Refactored `ClaimingCandidateStrategy`, `PointingCandidateStrategy`, and `HiddenSingleStrategy` to simplify logic, improve readability, and add detailed KDoc documentation for each strategy. This includes extracting group type logic, improving candidate filtering, and using more idiomatic Kotlin. [[1]](diffhunk://#diff-d8cd1f0166830f1a6d274afa5deee5d8fb1faea0307c17b68daba7e3272d29dfL7-R79) [[2]](diffhunk://#diff-54941a73cb270a1774642860d4d20746971c1ecc44b3bcbc1fbb5f063d6cc193L7-L81) [[3]](diffhunk://#diff-d243353628bd9f8ffe184297db66d18d81a809b7d162d6fa152e11bc303d37b9R9-R44) [[4]](diffhunk://#diff-659ed07338f0acf4d9abb347ff0bcfed3dda591dd83e687146a47670f25f3c09R8-R17)

**Testing Improvements:**

- Added a new `ClaimingCandidateStrategyTest` class with comprehensive test cases to verify correct detection of claiming candidates in rows and columns, as well as edge cases with multiple or no candidates.
- Introduced a `TestUtils.kt` file with helper functions for generating Sudoku houses and setting candidates for cells, streamlining test setup and improving test code clarity.