### PR TITLE
fix: clear notes when applying hints (#73)

### DIFF
--- a/domain/game/src/main/java/io/github/mgrablo/sudokuslayer/domain/game/usecases/hint/RevealHintOnGridUseCase.kt
+++ b/domain/game/src/main/java/io/github/mgrablo/sudokuslayer/domain/game/usecases/hint/RevealHintOnGridUseCase.kt
@@ -3,48 +3,37 @@ package io.github.mgrablo.sudokuslayer.domain.game.usecases.hint
 import io.github.mgrablo.sudokucore.hints.Hint
 import io.github.mgrablo.sudokucore.hints.HintType
 import io.github.mgrablo.sudokucore.model.SudokuGrid
-import io.github.mgrablo.sudokuslayer.domain.game.usecases.input.InputNumberUseCase
+import io.github.mgrablo.sudokuslayer.domain.game.GameUpdate
+import io.github.mgrablo.sudokuslayer.domain.game.usecases.game.CalculateGridChangesUseCase
 
-class RevealHintOnGridUseCase(private val inputNumberUseCase: InputNumberUseCase) {
-	suspend operator fun invoke(hint: Hint, grid: SudokuGrid): SudokuGrid = when (hint.type) {
-		is HintType.PointingCandidate -> revealPointingCandidate(hint, grid)
+class RevealHintOnGridUseCase(
+	private val calculateGridChangesUseCase: CalculateGridChangesUseCase,
+) {
+	suspend operator fun invoke(hint: Hint, grid: SudokuGrid): GameUpdate = when (hint.type) {
+		is HintType.PointingCandidate,
+		is HintType.ClaimingCandidate,
+		-> applyNoteHints(hint, grid)
 
-		is HintType.ClaimingCandidate -> revealClaimingCandidate(hint, grid)
-
-		is HintType.HiddenSingle, is HintType.NakedSingle ->
-			inputNumberUseCase(
-				sudokuGrid = grid,
-				number = hint.value,
-				row = hint.row,
-				column = hint.col,
-				isNote = false,
-				isHint = true,
-			)
+		is HintType.HiddenSingle,
+		is HintType.NakedSingle,
+		-> placeHintDigit(hint, grid)
 	}
 
-	private suspend fun revealPointingCandidate(hint: Hint, grid: SudokuGrid): SudokuGrid {
-		val otherCells = hint.enforcingCells
-		var updatedGrid = grid
-		otherCells.forEach { cell ->
-			updatedGrid =
-				inputNumberUseCase(
-					sudokuGrid = updatedGrid,
-					number = hint.value,
-					row = cell.row,
-					column = cell.col,
-					isNote = true,
-					isHint = true,
-				)
-		}
-		return updatedGrid
-	}
+	private suspend fun placeHintDigit(hint: Hint, grid: SudokuGrid): GameUpdate =
+		calculateGridChangesUseCase(
+			initialGrid = grid,
+			number = hint.value,
+			row = hint.row,
+			column = hint.col,
+			isNote = false,
+			isHint = true,
+		)
 
-	private suspend fun revealClaimingCandidate(hint: Hint, grid: SudokuGrid): SudokuGrid {
-		val otherCells = hint.enforcingCells
-		var updatedGrid = grid
-		otherCells.forEach { cell ->
-			updatedGrid = inputNumberUseCase(
-				sudokuGrid = updatedGrid,
+	private suspend fun applyNoteHints(hint: Hint, grid: SudokuGrid): GameUpdate {
+		val enforcingCells = hint.enforcingCells
+		return enforcingCells.fold(GameUpdate(grid, emptyList())) { acc, cell ->
+			calculateGridChangesUseCase(
+				initialGrid = acc.resultingGrid,
 				number = hint.value,
 				row = cell.row,
 				column = cell.col,
@@ -52,6 +41,5 @@ class RevealHintOnGridUseCase(private val inputNumberUseCase: InputNumberUseCase
 				isHint = true,
 			)
 		}
-		return updatedGrid
 	}
 }

--- a/feature/game/src/main/java/io/github/mgrablo/sudokuslayer/feature/game/SudokuGameViewModel.kt
+++ b/feature/game/src/main/java/io/github/mgrablo/sudokuslayer/feature/game/SudokuGameViewModel.kt
@@ -568,11 +568,12 @@ internal class SudokuGameViewModel(
 			}
 			selectCell(hint.row, hint.col)
 			updateGame { currentGame ->
-				val updatedSudoku = hintUseCases.revealOnGrid(hint, currentGame.grid)
+				val (updatedGrid, changes) = hintUseCases.revealOnGrid(hint, currentGame.grid)
 				val updatedLogs = hintUseCases.revealLastLog(currentGame.hintLogs)
 
+				recordUndoOperation(changes)
 				currentGame.copy(
-					grid = updatedSudoku,
+					grid = updatedGrid,
 					hintLogs = updatedLogs,
 				)
 			}


### PR DESCRIPTION
Fixed a bug in `RevealHintOnGridUseCase` where applied hints did not update conflicting notes.

### Changes:

* Updated `RevealHintOnGridUseCase` to use `CalculateGridChangesUseCase` for both placing digits and applying note hints. Changed return type to a `GameUpdate` (updated grid and changes) instead of just the updated grid.
* Updated `SudokuGameViewModel` to unpack the `GameUpdate` from `revealOnGrid`, record undo operations using the list of changes, and update the grid accordingly.

Closes #73