### PR TITLE
Feat/add release workflow

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,0 +1,107 @@
+name: Release on Github
+
+on:
+    push:
+        tags:
+            - 'v*'
+    workflow_dispatch: { }
+
+permissions:
+    contents: write
+
+jobs:
+    test:
+        name: Unit Test
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup JDK 17
+              uses: actions/setup-java@v4
+              with:
+                  distribution: 'temurin'
+                  java-version: 17
+                  cache: 'gradle'
+
+            - name: Grant execute permissions for gradlew
+              run: chmod +x gradlew
+
+            - name: Run unit tests
+              run: ./gradlew clean testDebug
+
+    build:
+        runs-on: ubuntu-latest
+        needs: test
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup JDK 17
+              uses: actions/setup-java@v4
+              with:
+                  distribution: "temurin"
+                  java-version: "17"
+
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v4
+
+
+            - name: Make gradlew executable
+              run: chmod +x ./gradlew
+
+            - name: Extract version from version catalog
+              run: |
+                  CATALOG_FILE="gradle/libs.versions.toml"
+                  VERSION_NAME=$(grep "appVersionName" $CATALOG_FILE | cut -d'"' -f2)
+                  
+                  if [ -z "$VERSION_NAME" ]; then
+                      echo "::error::Could not extract version name from $CATALOG_FILE."
+                      exit 1
+                  fi
+
+                  echo "Extracted version: $VERSION_NAME"
+                  echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
+
+            - name: Extract changelog
+              run: |
+                  VERSION="${{env.VERSION_NAME}}"
+                  CHANGELOG_FILE="CHANGELOG.md"
+                  OUTPUT_FILE="commit.txt"
+                  
+                  awk -v version="## ${VERSION}" '
+                      $0 ~ "^" version "$" {capture=1; next}
+                      /^## [0-9]/ && capture {exit}
+                      capture {print}
+                  ' ${CHANGELOG_FILE} > ${OUTPUT_FILE}
+                
+                  if [ ! -s "${OUTPUT_FILE}" ]; then
+                      echo "::warning file=${CHANGELOG_FILE}::Could not find changelog for version ${VERSION}. commit.txt will be empty."
+                  fi
+                
+                  echo "Changelog extracted to commit.txt"
+
+            - name: Build app bundle
+              run: |
+                  ./gradlew assembleRelease
+
+            - name: Sign app Apk
+              id: sign_app
+              uses: r0adkll/sign-android-release@v1
+              with:
+                  releaseDirectory: app/build/outputs/apk/release/
+                  signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+                  alias: ${{ secrets.ALIAS }}
+                  keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+                  keyPassword: ${{ secrets.KEY_PASSWORD }}
+
+            - name: Create GitHub Release
+              uses: softprops/action-gh-release@v2
+              with:
+                  make_latest: true
+                  files: ${{ steps.sign_app.outputs.signedReleaseFile }}
+                  body_path: commit.txt
+                  name: Release v${{ env.VERSION_NAME }}
+                  tag_name: v${{ env.VERSION_NAME }}
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 1.0.0
+* Initial release

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+/release

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,8 +27,13 @@ android {
 			libs.versions.android.targetSdk
 				.get()
 				.toInt()
-		versionCode = 1
-		versionName = "1.0"
+		versionCode =
+			libs.versions.appVersionCode
+				.get()
+				.toInt()
+		versionName =
+			libs.versions.appVersionName
+				.get()
 
 		testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 	}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,14 +40,16 @@ android {
 
 	buildTypes {
 		release {
-			isMinifyEnabled = false
+			isMinifyEnabled = true
+			isShrinkResources = true
+			isDebuggable = false
 			proguardFiles(
 				getDefaultProguardFile("proguard-android-optimize.txt"),
 				"proguard-rules.pro",
 			)
-			signingConfig = signingConfigs.getByName("debug")
 		}
 		debug {
+			isDebuggable = true
 			applicationIdSuffix = ".debug"
 		}
 	}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,7 @@
 [versions]
+appVersionName = "1.0.0"
+appVersionCode = "1"
+
 
 # Android
 kotlin = "2.2.20"


### PR DESCRIPTION
This pull request sets up a complete GitHub Actions workflow for automated releases, introduces version management via a version catalog, and updates the build configuration to support production-ready release builds. It also adds a changelog and improves `.gitignore` coverage. The most important changes are:

**CI/CD Automation:**
* Adds a `.github/workflows/github_release.yml` workflow that runs unit tests, builds the app, signs the APK, extracts the changelog, and creates a GitHub release on tagged pushes. This automates the release process and ensures only tested builds are released.

**Versioning and Changelog:**
* Introduces `appVersionName` and `appVersionCode` to `gradle/libs.versions.toml` for centralized version management.
* Adds a `CHANGELOG.md` file with an entry for the initial release.

**Build Configuration:**
* Updates `app/build.gradle.kts` to use version values from the version catalog, enables code shrinking and resource shrinking for release builds, and disables debugging for release builds.

**Project Cleanliness:**
* Updates `app/.gitignore` to exclude the `/release` directory, preventing accidental commits of release artifacts.