### PR TITLE
Feat/add language selection in settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,11 @@ android {
 		testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 	}
 
+	androidResources {
+		generateLocaleConfig = true
+		localeFilters.addAll(listOf("en", "pl"))
+	}
+
 	buildTypes {
 		release {
 			isMinifyEnabled = true

--- a/app/src/main/java/io/github/mgrablo/sudokuslayer/AppContent.kt
+++ b/app/src/main/java/io/github/mgrablo/sudokuslayer/AppContent.kt
@@ -1,7 +1,6 @@
 package io.github.mgrablo.sudokuslayer
 
 import android.app.Activity
-import android.app.Application
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
@@ -42,22 +41,7 @@ import io.github.mgrablo.sudokuslayer.feature.uicore.components.SudokuNavigation
 import io.github.mgrablo.sudokuslayer.feature.uicore.theme.SudokuSlayerTheme
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
-import org.koin.android.ext.koin.androidContext
-import org.koin.android.ext.koin.androidLogger
 import org.koin.androidx.compose.koinViewModel
-import org.koin.core.context.startKoin
-
-class MyApplication : Application() {
-	override fun onCreate() {
-		super.onCreate()
-
-		startKoin {
-			modules(appModule)
-			androidContext(this@MyApplication)
-			androidLogger()
-		}
-	}
-}
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -69,9 +53,9 @@ internal fun AppContent(viewModel: AppViewModel = koinViewModel()) {
 	)
 	val destinations =
 		persistentListOf(
-			_root_ide_package_.io.github.mgrablo.sudokuslayer.feature.game.SudokuGame(),
+			SudokuGame(),
 			SudokuCreator(),
-			_root_ide_package_.io.github.mgrablo.sudokuslayer.feature.statistics.Insights,
+			Insights,
 			Settings,
 		)
 	val scope = rememberCoroutineScope()

--- a/app/src/main/java/io/github/mgrablo/sudokuslayer/MainActivity.kt
+++ b/app/src/main/java/io/github/mgrablo/sudokuslayer/MainActivity.kt
@@ -1,16 +1,45 @@
 package io.github.mgrablo.sudokuslayer
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import io.github.mgrablo.sudokuslayer.domain.settings.SettingsRepository
+import io.github.mgrablo.sudokuslayer.domain.settings.models.Language
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
+
+	private val settingsRepository: SettingsRepository by inject()
+
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 		enableEdgeToEdge()
 		WindowCompat.setDecorFitsSystemWindows(window, false)
+
+		lifecycleScope.launch {
+			repeatOnLifecycle(Lifecycle.State.STARTED) {
+				settingsRepository.language.collect { language ->
+					val tag = if (language == Language.SYSTEM) "" else language.tag
+					val localeList = if (tag.isEmpty()) {
+						LocaleListCompat.getEmptyLocaleList()
+					} else {
+						LocaleListCompat.forLanguageTags(tag)
+					}
+
+					if (AppCompatDelegate.getApplicationLocales() != localeList) {
+						AppCompatDelegate.setApplicationLocales(localeList)
+					}
+				}
+			}
+		}
 
 		setContent {
 			AppContent()

--- a/app/src/main/java/io/github/mgrablo/sudokuslayer/MyApplication.kt
+++ b/app/src/main/java/io/github/mgrablo/sudokuslayer/MyApplication.kt
@@ -1,0 +1,38 @@
+package io.github.mgrablo.sudokuslayer
+
+import android.app.Application
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import io.github.mgrablo.sudokuslayer.domain.settings.SettingsRepository
+import io.github.mgrablo.sudokuslayer.domain.settings.models.Language
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.koin.android.ext.android.inject
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.context.startKoin
+
+class MyApplication : Application() {
+	override fun onCreate() {
+		super.onCreate()
+
+		startKoin {
+			modules(appModule)
+			androidContext(this@MyApplication)
+			androidLogger()
+		}
+
+		val settingsRepository: SettingsRepository by inject()
+		runBlocking {
+			val language = settingsRepository.language.first()
+			val tag = if (language == Language.SYSTEM) "" else language.tag
+			val localeList = if (tag.isEmpty()) {
+				LocaleListCompat.getEmptyLocaleList()
+			} else {
+				LocaleListCompat.forLanguageTags(tag)
+			}
+
+			AppCompatDelegate.setApplicationLocales(localeList)
+		}
+	}
+}

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.SudokuSlayer" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.SudokuSlayer" parent="Theme.AppCompat.DayNight.NoActionBar" />
 </resources>

--- a/data/settings/src/main/java/io/github/mgrablo/sudokuslayer/data/settings/AndroidSettingsRepository.kt
+++ b/data/settings/src/main/java/io/github/mgrablo/sudokuslayer/data/settings/AndroidSettingsRepository.kt
@@ -4,6 +4,7 @@ import io.github.mgrablo.sudokuslayer.data.core.preferences.PreferenceStorage
 import io.github.mgrablo.sudokuslayer.domain.settings.SettingsRepository
 import io.github.mgrablo.sudokuslayer.domain.settings.models.ColorScheme
 import io.github.mgrablo.sudokuslayer.domain.settings.models.DarkMode
+import io.github.mgrablo.sudokuslayer.domain.settings.models.Language
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -27,10 +28,10 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 			.map { it.orEmpty() }
 			.map { ColorScheme.fromName(it) }
 
-	override val language: Flow<String> = preferenceStorage.getAsFlow(
+	override val language: Flow<Language> = preferenceStorage.getAsFlow(
 		SettingsPreferenceKeys.Language,
 	).map {
-		it.orEmpty()
+		Language.fromTag(it.orEmpty())
 	}
 	override val leftHandMode: Flow<Boolean> = preferenceStorage.getAsFlow(
 		SettingsPreferenceKeys.LeftHandMode,
@@ -77,8 +78,8 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 		preferenceStorage.set(SettingsPreferenceKeys.LightColorScheme, colorScheme.name)
 	}
 
-	override suspend fun setLanguage(language: String) {
-		preferenceStorage.set(SettingsPreferenceKeys.Language, language)
+	override suspend fun setLanguage(language: Language) {
+		preferenceStorage.set(SettingsPreferenceKeys.Language, language.tag)
 	}
 
 	override suspend fun setLeftHandMode(leftHandMode: Boolean) {
@@ -126,6 +127,8 @@ class AndroidSettingsRepository(private val preferenceStorage: PreferenceStorage
 	}
 
 	override fun getAvailableColorSchemes(): List<ColorScheme> = ColorScheme.getAvailableColorSchemes()
+
+	override fun getAvailableLanguages(): List<Language> = Language.getAvailableLanguages()
 
 	override fun getDarkColorSchemes(): List<ColorScheme> = ColorScheme.getDarkColorSchemes()
 

--- a/domain/settings/src/main/java/io/github/mgrablo/sudokuslayer/domain/settings/SettingsRepository.kt
+++ b/domain/settings/src/main/java/io/github/mgrablo/sudokuslayer/domain/settings/SettingsRepository.kt
@@ -2,13 +2,14 @@ package io.github.mgrablo.sudokuslayer.domain.settings
 
 import io.github.mgrablo.sudokuslayer.domain.settings.models.ColorScheme
 import io.github.mgrablo.sudokuslayer.domain.settings.models.DarkMode
+import io.github.mgrablo.sudokuslayer.domain.settings.models.Language
 import kotlinx.coroutines.flow.Flow
 
 interface SettingsRepository {
 	val darkMode: Flow<DarkMode>
 	val darkModeColorScheme: Flow<ColorScheme>
 	val lightModeColorScheme: Flow<ColorScheme>
-	val language: Flow<String>
+	val language: Flow<Language>
 	val leftHandMode: Flow<Boolean>
 	val showActionButtonsOnTop: Flow<Boolean>
 	val insightsSummaryCompactLayout: Flow<Boolean>
@@ -24,7 +25,7 @@ interface SettingsRepository {
 
 	suspend fun setLightColorScheme(colorScheme: ColorScheme)
 
-	suspend fun setLanguage(language: String)
+	suspend fun setLanguage(language: Language)
 
 	suspend fun setLeftHandMode(leftHandMode: Boolean)
 
@@ -43,6 +44,8 @@ interface SettingsRepository {
 	suspend fun setRemainingDigitCounts(remainingDigitCounts: Boolean)
 
 	fun getAvailableColorSchemes(): List<ColorScheme>
+
+	fun getAvailableLanguages(): List<Language>
 
 	fun getDarkColorSchemes(): List<ColorScheme>
 

--- a/domain/settings/src/main/java/io/github/mgrablo/sudokuslayer/domain/settings/models/Language.kt
+++ b/domain/settings/src/main/java/io/github/mgrablo/sudokuslayer/domain/settings/models/Language.kt
@@ -1,0 +1,16 @@
+package io.github.mgrablo.sudokuslayer.domain.settings.models
+
+enum class Language(val tag: String) {
+	SYSTEM("system"),
+	ENGLISH("en"),
+	POLISH("pl");
+
+	companion object {
+		fun fromTag(tag: String): Language {
+			return entries.find { it.tag == tag } ?: SYSTEM
+		}
+
+		fun getAvailableLanguages(): List<Language> = entries
+	}
+}
+

--- a/feature/settings/src/main/java/io/github/mgrablo/sudokuslayer/feature/settings/LanguageExtensions.kt
+++ b/feature/settings/src/main/java/io/github/mgrablo/sudokuslayer/feature/settings/LanguageExtensions.kt
@@ -1,0 +1,14 @@
+package io.github.mgrablo.sudokuslayer.feature.settings
+
+import androidx.annotation.StringRes
+import io.github.mgrablo.sudokuslayer.domain.settings.models.Language
+
+@StringRes
+fun Language.getTitleRes(): Int {
+	return when (this) {
+		Language.SYSTEM -> R.string.language_system
+		Language.ENGLISH -> R.string.language_english
+		Language.POLISH -> R.string.language_polish
+	}
+}
+

--- a/feature/settings/src/main/java/io/github/mgrablo/sudokuslayer/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/io/github/mgrablo/sudokuslayer/feature/settings/SettingsScreen.kt
@@ -85,17 +85,28 @@ private fun SettingsScreenContent(
 	) { paddingValues ->
 		Column(
 			modifier =
-			Modifier
-				.fillMaxSize()
-				.verticalScroll(rememberScrollState())
-				.padding(paddingValues)
-				.padding(LocalPadding.current.normal),
+				Modifier
+					.fillMaxSize()
+					.verticalScroll(rememberScrollState())
+					.padding(paddingValues)
+					.padding(LocalPadding.current.normal),
 		) {
 			var themeExpanded by remember { mutableStateOf(false) }
 			var lightColorSchemeExpanded by remember { mutableStateOf(false) }
 			var darkColorSchemeExpanded by remember { mutableStateOf(false) }
+			var languageExpanded by remember { mutableStateOf(false) }
 
 			SettingsCategory(stringResource(R.string.appearance)) {
+				SettingDropDownMenu(
+					title = stringResource(R.string.language),
+					isExpanded = languageExpanded,
+					onExpandedChange = { languageExpanded = it },
+					selectedValue = uiState.appearance.language,
+					onSelect = { onEvent(SettingsViewModel.Event.SetLanguage(it)) },
+					optionToString = { stringResource(it.getTitleRes()) },
+					options = uiState.availableLanguages,
+					modifier = Modifier.fillMaxWidth(),
+				)
 				SettingDropDownMenu(
 					title = stringResource(R.string.theme),
 					description = if (uiState.appearance.darkMode == DarkMode.SYSTEM) {

--- a/feature/settings/src/main/java/io/github/mgrablo/sudokuslayer/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/io/github/mgrablo/sudokuslayer/feature/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import io.github.mgrablo.sudokuslayer.domain.settings.SettingsRepository
 import io.github.mgrablo.sudokuslayer.domain.settings.models.ColorScheme
 import io.github.mgrablo.sudokuslayer.domain.settings.models.DarkMode
 import io.github.mgrablo.sudokuslayer.domain.settings.models.Language
+import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -17,6 +18,8 @@ internal data class SettingsUiState(
 	val appearance: AppearanceSettings = AppearanceSettings(),
 	val accessibility: AccessibilitySettings = AccessibilitySettings(),
 	val gameplay: GameplaySettings = GameplaySettings(),
+	val availableLanguages: PersistentSet<Language> = Language.getAvailableLanguages()
+		.toPersistentSet(),
 )
 
 internal data class AppearanceSettings(

--- a/feature/settings/src/main/java/io/github/mgrablo/sudokuslayer/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/io/github/mgrablo/sudokuslayer/feature/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import io.github.mgrablo.sudokuslayer.domain.settings.SettingsRepository
 import io.github.mgrablo.sudokuslayer.domain.settings.models.ColorScheme
 import io.github.mgrablo.sudokuslayer.domain.settings.models.DarkMode
+import io.github.mgrablo.sudokuslayer.domain.settings.models.Language
 import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -23,7 +24,7 @@ internal data class AppearanceSettings(
 	val darkColorScheme: ColorScheme = ColorScheme.fromName("mocha"),
 	val lightColorScheme: ColorScheme = ColorScheme.fromName("latte"),
 	val insightsSummaryCompactLayout: Boolean = true,
-	val language: String = "system",
+	val language: Language = Language.SYSTEM,
 )
 
 internal data class AccessibilitySettings(
@@ -116,17 +117,11 @@ internal class SettingsViewModel(private val settingsRepository: SettingsReposit
 
 	sealed interface Event {
 		data class SetDarkMode(val darkMode: DarkMode) : Event
-
+		data class SetLanguage(val language: Language) : Event
 		data class SetDarkColorScheme(val colorScheme: ColorScheme) : Event
-
 		data class SetLightColorScheme(val colorScheme: ColorScheme) : Event
-
-		data class SetLanguage(val language: String) : Event
-
 		data class ToggleLeftHandMode(val leftHandMode: Boolean) : Event
-
 		data class ToggleActionButtonsOnTop(val actionButtonsOnTop: Boolean) : Event
-
 		data class ToggleInsightsSummaryCompactLayout(val compactLayout: Boolean) : Event
 		data class ToggleAutoClearNotes(val autoClearNotes: Boolean) : Event
 		data class ToggleHighlightMatching(val highlightMatching: Boolean) : Event
@@ -138,19 +133,29 @@ internal class SettingsViewModel(private val settingsRepository: SettingsReposit
 	fun onEvent(event: Event) {
 		when (event) {
 			is Event.SetDarkMode -> setDarkMode(event.darkMode)
-			is Event.SetLightColorScheme -> setLightColorScheme(event.colorScheme)
+
 			is Event.SetDarkColorScheme -> setDarkColorScheme(event.colorScheme)
+
 			is Event.SetLanguage -> setLanguage(event.language)
+
+			is Event.SetLightColorScheme -> setLightColorScheme(event.colorScheme)
+
 			is Event.ToggleLeftHandMode -> toggleLeftHandMode(event.leftHandMode)
+
 			is Event.ToggleActionButtonsOnTop -> toggleActionButtonsOnTop(event.actionButtonsOnTop)
+
 			is Event.ToggleInsightsSummaryCompactLayout -> toggleInsightsSummaryCompactLayout(
 				event.compactLayout,
 			)
 
 			is Event.ToggleAutoClearNotes -> toggleAutoClearNotes(event.autoClearNotes)
+
 			is Event.ToggleHighlightMatching -> toggleHighlightMatching(event.highlightMatching)
+
 			is Event.ToggleHighlightInvalid -> toggleHighlightInvalid(event.highlightInvalid)
+
 			is Event.ToggleTimerVisibility -> toggleTimerVisibility(event.timerVisibility)
+
 			is Event.ToggleRemainingDigitCounts -> toggleRemainingDigitCounts(event.remainingDigitCounts)
 		}
 	}
@@ -179,7 +184,7 @@ internal class SettingsViewModel(private val settingsRepository: SettingsReposit
 		}
 	}
 
-	private fun setLanguage(language: String) {
+	private fun setLanguage(language: Language) {
 		viewModelScope.launch {
 			settingsRepository.setLanguage(language)
 		}

--- a/feature/settings/src/main/res/values-pl/strings.xml
+++ b/feature/settings/src/main/res/values-pl/strings.xml
@@ -25,4 +25,5 @@
 	<string name="clear_notes_when_a_number_is_input">Wyczyść notatki po wpisaniu liczby</string>
 	<string name="settings_title">Ustawienia</string>
 	<string name="open_menu_content_desc">Otwórz menu</string>
+	<string name="language_system">Domyślny systemowy</string>
 </resources>

--- a/feature/settings/src/main/res/values-pl/strings.xml
+++ b/feature/settings/src/main/res/values-pl/strings.xml
@@ -26,4 +26,5 @@
 	<string name="settings_title">Ustawienia</string>
 	<string name="open_menu_content_desc">Otwórz menu</string>
 	<string name="language_system">Domyślny systemowy</string>
+	<string name="language">Język</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -25,4 +25,7 @@
 	<string name="clear_notes_when_a_number_is_input">Clear notes when a number is input</string>
 	<string name="settings_title">Settings</string>
 	<string name="open_menu_content_desc">Open menu</string>
+	<string name="language_system">System Default</string>
+	<string name="language_english" translatable="false">English</string>
+	<string name="language_polish" translatable="false">Polski</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -28,4 +28,5 @@
 	<string name="language_system">System Default</string>
 	<string name="language_english" translatable="false">English</string>
 	<string name="language_polish" translatable="false">Polski</string>
+	<string name="language">Language</string>
 </resources>


### PR DESCRIPTION
This pull request implements per-app language settings (currently supports English and Polish).
 
 Changes:
- Add a `Language` model and update settings repository
- Update the settings UI to allow language selection
- Apply the selected language at app startup and when changed